### PR TITLE
Update GitHub Actions checkout runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v8.2.0
       - name: Verify tag matches package version
         shell: bash


### PR DESCRIPTION
Move CI and release workflows from actions/checkout@v4 to @v5 so the workflows use the current Node 24 runtime line and avoid the Node.js 20 deprecation warning.