### PR TITLE
Release altium-cruncher 2026.6.22

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Describe the change and the public behavior it affects.
 
-Linked issue or discussion:
+Linked issue:
 
 Design agreement summary:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
             $errors | Format-List | Out-String | Write-Error
             exit 1
           }
+      - name: Check Wavenumber development standard
+        run: uvx --from git+https://github.com/wavenumber-eng/wn-dev-std.git wn-dev-std check . --format text
       - name: Run Rack suite
         run: uv run --extra test rack run --all
       - name: Build package

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,109 @@
+name: PR Hygiene
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  hygiene:
+    name: metadata and commit hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR metadata and commits
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const failures = [];
+
+            const bannedPatterns = [
+              { pattern: /\bclaude\b/i, message: "mentions Claude" },
+              { pattern: /\banthropic\b/i, message: "mentions Anthropic" },
+              { pattern: /\bgenerated\s+with\b/i, message: "uses generated-with attribution" },
+              { pattern: /\bco-authored-by:\s*(claude|anthropic)\b/i, message: "uses AI-vendor co-author attribution" },
+              { pattern: /\b(just|simply|obviously|minor|small|quick|stuff|things|misc|various)\b/i, message: "uses non-factual filler language" },
+            ];
+            const emojiPattern = /[\p{Extended_Pictographic}\uFE0F]/u;
+
+            function checkText(label, text) {
+              const value = text || "";
+              if (emojiPattern.test(value)) {
+                failures.push(`${label} contains emoji or pictographic symbols.`);
+              }
+              for (const { pattern, message } of bannedPatterns) {
+                if (pattern.test(value)) {
+                  failures.push(`${label} ${message}.`);
+                }
+              }
+            }
+
+            function issueNumbersFrom(text) {
+              const value = text || "";
+              const numbers = new Set();
+              const sameRepoIssueUrl = new RegExp(
+                `https://github\\.com/${owner}/${repo}/issues/(\\d+)`,
+                "gi",
+              );
+              for (const match of value.matchAll(sameRepoIssueUrl)) {
+                numbers.add(Number(match[1]));
+              }
+              for (const match of value.matchAll(/(^|[^\w/])#(\d+)\b/g)) {
+                numbers.add(Number(match[2]));
+              }
+              return [...numbers];
+            }
+
+            checkText("PR title", pr.title);
+            checkText("PR body", pr.body || "");
+
+            const linkedIssueLine = (pr.body || "")
+              .split(/\r?\n/)
+              .find((line) => /^Linked issue:/i.test(line));
+            const issueNumbers = issueNumbersFrom(linkedIssueLine || "");
+            if (!linkedIssueLine || issueNumbers.length === 0) {
+              failures.push("PR body must fill in `Linked issue:` with an existing same-repo issue such as `#123`.");
+            }
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                const response = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                });
+                if (response.data.pull_request) {
+                  failures.push(`#${issueNumber} is a pull request, not an issue.`);
+                }
+              } catch (error) {
+                failures.push(`Linked issue #${issueNumber} does not exist or is not readable.`);
+              }
+            }
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            for (const commit of commits) {
+              const message = commit.commit.message || "";
+              const subject = message.split(/\r?\n/, 1)[0];
+              checkText(`Commit ${commit.sha.slice(0, 7)} message`, message);
+              if (subject.length > 72) {
+                failures.push(`Commit ${commit.sha.slice(0, 7)} subject is ${subject.length} characters; keep it at 72 or fewer.`);
+              }
+              if (/^wip\b/i.test(subject)) {
+                failures.push(`Commit ${commit.sha.slice(0, 7)} subject starts with WIP.`);
+              }
+            }
+
+            if (failures.length > 0) {
+              core.setFailed(`PR hygiene failed:\n- ${failures.join("\n- ")}`);
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026.6.22
+
+- Consume pinned `altium-monkey==2026.6.21`, including the corrected rounded
+  rectangle pad corner-ratio projection and updated PcbLib cavity-region
+  authoring/readback behavior.
+- Add a GitHub PR hygiene gate that requires public pull requests to link an
+  existing same-repo issue and rejects emoji, AI-vendor attribution, and common
+  non-factual filler in PR metadata and commit messages.
+- Run the Wavenumber development-standard check in CI so public pull requests
+  exercise the same repo-shape gate documented for local development.
+
 ## 2026.6.17
 
 - Consume pinned `altium-monkey==2026.6.16`, including the public mechanical

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,7 @@ be shared publicly.
 
 ## Contribution Workflow
 
-Open an issue or GitHub Discussion before starting a public PR, unless the
-change is a small documentation typo or an obviously isolated bug fix.
+Open a GitHub issue before starting a public PR.
 
 For any public command, config, JSON, generated artifact, API, dependency, or
 workflow change, contributors should agree on the design first. That discussion
@@ -20,9 +19,9 @@ should settle the intended command behavior, config shape and defaults, expected
 outputs, compatibility impact, docs updates, and required tests before a PR is
 considered ready for review.
 
-PRs that change public behavior should link the issue or discussion where the
-design was agreed and include the matching design-doc, contract, and test
-updates.
+PRs should link the issue where the design or bug report was recorded. PRs that
+change public behavior should also include the matching design-doc, contract,
+and test updates.
 
 ## Commit Messages And Human Signoff
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ release workflow is GitHub Actions plus PyPI Trusted Publishing/OIDC. Local
 Twine upload is fallback only.
 
 Current release notes are available in
-`docs/releases/2026-06-14.md`.
+`docs/releases/2026-06-22.md`.
 
 `altium-cruncher` remains AGPL-3.0-or-later because it imports and depends on
 the AGPL `altium-monkey` package for normal operation.

--- a/docs/releases/2026-06-22.md
+++ b/docs/releases/2026-06-22.md
@@ -1,0 +1,34 @@
+# Release Notes - 2026-06-22
+
+These notes describe the 2026-06-22 public release for `altium-cruncher`
+package version `2026.6.22`.
+
+## Release Status
+
+This release refreshes the controlled Altium Monkey dependency and tightens
+public pull-request hygiene.
+
+Please report issues with the exact command, version output, expected behavior,
+actual behavior, and a public-safe reproduction fixture when possible.
+
+## Highlights
+
+- The package consumes pinned `altium-monkey==2026.6.21`.
+- The package continues to consume pinned `wn-geometer==2026.6.10`.
+- The Altium Monkey dependency includes the corrected rounded rectangle pad
+  corner-ratio projection used by downstream visualization and conversion
+  checks.
+- The Altium Monkey dependency includes updated PcbLib cavity-region
+  authoring/readback behavior.
+- Pull requests now run a hygiene gate for same-repo issue links, concise
+  factual metadata, no emoji, and no AI-vendor attribution in commit messages
+  or PR text.
+- CI now runs the Wavenumber development-standard check in addition to Rack,
+  package build, distribution validation, and installed-console smoke tests.
+
+## Known Caveats
+
+- Local Altium launch, OutJob execution, and profile cleanup still require
+  Windows with Altium Designer/profile folders present. Discovery/list commands
+  are safe to exercise on Linux/macOS and return empty results when no local
+  Altium state exists.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "altium-cruncher"
-version = "2026.6.17"
+version = "2026.6.22"
 description = "Cross-platform Altium CLI utilities built on public altium-monkey"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -9,7 +9,7 @@ authors = [
     { name = "Wavenumber LLC" },
 ]
 dependencies = [
-    "altium-monkey==2026.6.16",
+    "altium-monkey==2026.6.21",
     "colorama>=0.4.6",
     "easyeda-monkey>=2026.5.26",
     "json-with-comments>=1.2.10",

--- a/src/py/altium_cruncher/_version.py
+++ b/src/py/altium_cruncher/_version.py
@@ -8,7 +8,7 @@ from datetime import date
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 
-__version__ = "2026.6.17"
+__version__ = "2026.6.22"
 
 _DISTRIBUTION_NAME = "altium-cruncher"
 _CONTROLLED_DEPENDENCIES = (

--- a/tests/L99_signoff/test_L99_001_release_signoff.py
+++ b/tests/L99_signoff/test_L99_001_release_signoff.py
@@ -23,11 +23,11 @@ def _project_root() -> Path:
 
 
 PACKAGE_ROOT = _project_root()
-EXPECTED_VERSION = "2026.6.17"
-EXPECTED_RELEASE_DATE = date(2026, 6, 17)
-EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-06-17.md"
+EXPECTED_VERSION = "2026.6.22"
+EXPECTED_RELEASE_DATE = date(2026, 6, 22)
+EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-06-22.md"
 CONTROLLED_DEPENDENCIES = {
-    "altium-monkey": "2026.6.16",
+    "altium-monkey": "2026.6.21",
     "wn-geometer": "2026.6.10",
 }
 
@@ -43,7 +43,7 @@ def test_version_contract_matches_date_based_release() -> None:
     assert (version.major, version.minor, version.patch, version.build) == (
         2026,
         6,
-        17,
+        22,
         None,
     )
     assert version.release_date == EXPECTED_RELEASE_DATE

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.12.*"
 
 [[package]]
 name = "altium-cruncher"
-version = "2026.6.17"
+version = "2026.6.22"
 source = { editable = "." }
 dependencies = [
     { name = "altium-monkey" },
@@ -40,7 +40,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "altium-monkey", specifier = "==2026.6.16" },
+    { name = "altium-monkey", specifier = "==2026.6.21" },
     { name = "build", marker = "extra == 'test'", specifier = ">=1.2.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "easyeda-monkey", specifier = ">=2026.5.26" },
@@ -70,7 +70,7 @@ dev = [
 
 [[package]]
 name = "altium-monkey"
-version = "2026.6.16"
+version = "2026.6.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "freetype-py" },
@@ -80,9 +80,9 @@ dependencies = [
     { name = "uharfbuzz" },
     { name = "wn-geometer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/1e/569e6adaa0f832dcfb62ae59617ebae99442ff2a445d354bdd104524d042/altium_monkey-2026.6.16.tar.gz", hash = "sha256:9873185a97d31ebc3fa67a04fc70097fb2f919f092f5c1f3e61101a69bd50ef6", size = 1150091, upload-time = "2026-06-16T19:28:03.852Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/18/b24ac01b16576648721d88c3ceca1103f37d4058d7e919566937363bf122/altium_monkey-2026.6.21.tar.gz", hash = "sha256:04b0dc5958869ebaf5feabc0a300fba16b62de6ecef368134cabc58e1b5d5456", size = 1153755, upload-time = "2026-06-22T02:58:24.32Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/35/43f76bdf8bc28cf2bf9c9d67ca2e0abe2d4009f4f3071c0b99bea9492a0b/altium_monkey-2026.6.16-py3-none-any.whl", hash = "sha256:2b75df9e06be500f4ecf5f2b93d3b9ea0abd4808f9abd882a36d1133d30b1192", size = 1238287, upload-time = "2026-06-16T19:28:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4e/cf85596b5eae9ad8f80b0d81ab75dbdf7bc5748b57f828c9b0b68c98477e/altium_monkey-2026.6.21-py3-none-any.whl", hash = "sha256:0aac372a6e67829b2f9019e288398a2eb0b7d9defe00ffe5ed9933e25c81ab83", size = 1242388, upload-time = "2026-06-22T02:58:22.62Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
﻿## Summary

Release altium-cruncher 2026.6.22 with the controlled altium-monkey dependency updated to 2026.6.21 and CI hygiene for public pull requests.

Linked issue: #12

Design agreement summary: release dependency refresh and public PR hygiene policy.

## Scope

- [ ] Bug fix
- [ ] Documentation only
- [x] Test or CI update
- [ ] Public command behavior
- [ ] Public JSON/config/API contract
- [x] Packaging or dependency change

## Validation

- [x] `uv run --extra test rack run --all`
- [x] `uvx --from git+https://github.com/wavenumber-eng/wn-dev-std.git wn-dev-std check . --format json`
- [x] `uv run --extra test python -m build`
- [x] `uv run --extra test twine check dist\*`
- [x] `uv run --extra test python tests\support_scripts\install_test.py`

## Public Surface And Contracts

- [x] No public CLI, JSON, config, or API contract changed
- [x] Public behavior was discussed and agreed before this PR, if changed
- [ ] Command manifest updated if commands changed
- [ ] Command design docs updated if command behavior changed
- [ ] Contract docs updated for stable JSON/config/API changes
- [ ] Contract tests updated for stable JSON/config/API changes
- [ ] Generated default configs still include JSONC option comments, if relevant

## Dependencies And Release Impact

- [ ] No new dependency
- [x] New dependency is justified in this PR and has compatible licensing
- [x] Release notes or ADR added for compatibility, policy, or public contract changes

## Signoff

- [x] Commit messages are concise, factual, and contain no emoji
- [x] PR summary is to the point and limited to facts
- [x] Human signoff names the responsible person or GitHub user ID
- [ ] AI assistance is noted as implementation context only, if applicable

Human signoff: @ehughes

AI assistance note, if applicable: Codex assisted with implementation and validation.

## Notes For Reviewers

After merge, publish GitHub Release `v2026.6.22` to trigger PyPI trusted publishing.
