### PR TITLE
ci: require conventional PR subjects

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,9 @@ Describe the change and the public behavior it affects.
 
 Linked issue:
 
+PR title must use Conventional Commit form, such as `fix: handle missing board
+outline` or `ci: tighten pull request hygiene`.
+
 Design agreement summary:
 
 ## Scope

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -28,9 +28,15 @@ jobs:
               { pattern: /\banthropic\b/i, message: "mentions Anthropic" },
               { pattern: /\bgenerated\s+with\b/i, message: "uses generated-with attribution" },
               { pattern: /\bco-authored-by:\s*(claude|anthropic)\b/i, message: "uses AI-vendor co-author attribution" },
-              { pattern: /\b(just|simply|obviously|minor|small|quick|stuff|things|misc|various)\b/i, message: "uses non-factual filler language" },
             ];
             const emojiPattern = /[\p{Extended_Pictographic}\uFE0F]/u;
+            const conventionalSubjectPattern = /^(build|chore|ci|deps|docs|feat|fix|perf|refactor|release|revert|style|test)(\([A-Za-z0-9._-]+\))?!?: .+$/;
+
+            function checkConventionalSubject(label, subject) {
+              if (!conventionalSubjectPattern.test(subject || "")) {
+                failures.push(`${label} must use Conventional Commit form, for example \`fix: handle missing board outline\`.`);
+              }
+            }
 
             function checkText(label, text) {
               const value = text || "";
@@ -62,6 +68,7 @@ jobs:
 
             checkText("PR title", pr.title);
             checkText("PR body", pr.body || "");
+            checkConventionalSubject("PR title", pr.title || "");
 
             const linkedIssueLine = (pr.body || "")
               .split(/\r?\n/)
@@ -96,6 +103,7 @@ jobs:
               const message = commit.commit.message || "";
               const subject = message.split(/\r?\n/, 1)[0];
               checkText(`Commit ${commit.sha.slice(0, 7)} message`, message);
+              checkConventionalSubject(`Commit ${commit.sha.slice(0, 7)} subject`, subject);
               if (subject.length > 72) {
                 failures.push(`Commit ${commit.sha.slice(0, 7)} subject is ${subject.length} characters; keep it at 72 or fewer.`);
               }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,12 @@ and test updates.
 
 ## Commit Messages And Human Signoff
 
-Commit messages, PR summaries, and signoff notes should be concise, factual,
-and limited to what changed, why it changed, and how it was validated. Do not
-use emojis, decorative prefixes, or marketing-style language.
+Commit message subjects and PR titles must use Conventional Commit form:
+`type(optional-scope): description`. Allowed types are `build`, `chore`, `ci`,
+`deps`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `revert`,
+`style`, and `test`. Commit messages, PR summaries, and signoff notes should be
+concise, factual, and limited to what changed, why it changed, and how it was
+validated. Do not use emojis, decorative prefixes, or marketing-style language.
 
 Every PR signoff should identify the responsible human by name or GitHub user
 ID. If Claude or another AI coding agent materially assisted with the change,


### PR DESCRIPTION
﻿## Summary

Replace the broad filler-word PR hygiene rule with deterministic Conventional Commit checks for PR titles and commit subjects.

Linked issue: #14

Design agreement summary: keep issue links, emoji checks, AI-vendor attribution checks, WIP checks, and subject length checks; use Conventional Commit subjects instead of subjective filler-language matching.

## Scope

- [ ] Bug fix
- [ ] Documentation only
- [x] Test or CI update
- [ ] Public command behavior
- [ ] Public JSON/config/API contract
- [ ] Packaging or dependency change

## Validation

- [ ] `uv run --extra test rack run --all`
- [x] Targeted tests: local Node regex sanity check
- [ ] Manual command run, if relevant:

## Public Surface And Contracts

- [x] No public CLI, JSON, config, or API contract changed
- [x] Public behavior was discussed and agreed before this PR, if changed
- [ ] Command manifest updated if commands changed
- [ ] Command design docs updated if command behavior changed
- [ ] Contract docs updated for stable JSON/config/API changes
- [ ] Contract tests updated for stable JSON/config/API changes
- [ ] Generated default configs still include JSONC option comments, if relevant

## Dependencies And Release Impact

- [x] No new dependency
- [ ] New dependency is justified in this PR and has compatible licensing
- [ ] Release notes or ADR added for compatibility, policy, or public contract changes

## Signoff

- [x] Commit messages are concise, factual, and contain no emoji
- [x] PR summary is to the point and limited to facts
- [x] Human signoff names the responsible person or GitHub user ID
- [x] AI assistance is noted as implementation context only, if applicable

Human signoff: @ehughes

AI assistance note, if applicable: Codex assisted with implementation and validation.

## Notes For Reviewers

The allowed Conventional Commit types are `build`, `chore`, `ci`, `deps`, `docs`, `feat`, `fix`, `perf`, `refactor`, `release`, `revert`, `style`, and `test`.
