### PR TITLE
feat(query): add query command and altium-schematic Claude Code skill

### DIFF
--- a/.claude/skills/altium-schematic/SKILL.md
+++ b/.claude/skills/altium-schematic/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: altium-schematic
+description: Read Altium schematics and projects (.PrjPcb / .SchDoc) so Claude can answer questions about the circuit — components, nets, pin-level connectivity, BOM, and sheet hierarchy. Use whenever the user asks about an Altium design in this workspace.
+---
+
+# altium-schematic
+
+Lets Claude reason about Altium designs through the
+[`altium-cruncher`](https://github.com/wavenumber-eng/altium_cruncher) CLI.
+The `query` command exposes targeted subcommands so you load only the slice of
+design data relevant to the user's question into context — not the whole
+400KB+ design JSON.
+
+## When to use
+
+Trigger this skill when the user asks anything about an Altium design in the
+workspace, for example:
+
+- "what's connected to U7 pin C9?"
+- "list every IC on the codec sheet"
+- "which nets cross between sheets?"
+- "what's the BOM for the PCBA_Build variant?"
+- "what does this schematic do?"
+
+If you don't know which `.PrjPcb` they mean, run `find . -name '*.PrjPcb'` and
+ask if there's more than one.
+
+## Prerequisite
+
+The `altium-cruncher` CLI must be available. In an `altium-cruncher` repo
+clone, prefix commands with `uv run` so they use the project environment.
+Elsewhere, install the tool with `uv tool install altium-cruncher` (see the
+README) and call `altium-cruncher` directly.
+
+## How to invoke
+
+`query` subcommands print exactly one JSON payload to stdout. Errors print a
+one-line message to stderr with exit code 1. Each subcommand accepts the
+project as a positional path (or `--project`); with neither, it auto-detects a
+single `.PrjPcb` in the current working directory.
+
+```bash
+altium-cruncher query <subcommand> [project.PrjPcb] [options]
+```
+
+### Recommended starting point: `summary`
+
+Always run `summary` first when you encounter a project for the first time in
+a session. It's small and gives you sheet names, component/net counts,
+component-type breakdown, power nets, and variants — everything you need to
+plan follow-up queries.
+
+```bash
+altium-cruncher query summary path/to/Foo.PrjPcb
+```
+
+### Subcommands
+
+| Subcommand    | What it returns                                              | Typical question it answers                |
+| ------------- | ------------------------------------------------------------ | ------------------------------------------ |
+| `query summary`     | Project overview: sheets, counts, power nets, variants       | "What's in this project?"                  |
+| `query components`  | Filtered component list with `--designator`/`--sheet`/`--type`/`--value-contains` (brief rows by default; `--full` for everything) | "List the ICs on the regulator sheet."     |
+| `query nets`        | Net listing, or full terminal list with `--name NET`. Use `--contains` for substring match. | "What's on the SDA net?" / "Find P5V*."    |
+| `query connections` | Per-pin connectivity for a designator (`query connections U7 [--pin C9]`) | "What's wired to U7 pin C9?"               |
+| `query sheet`       | Single `.SchDoc` inspection (no project needed)              | "What does this one sheet contain?"        |
+
+### Related commands for bigger asks
+
+- **BOM:** `altium-cruncher bom project.PrjPcb --format generic-json -o <dir>`
+  writes `<Project>_bom.json`; add `--variant <name>` for variant BOMs.
+- **Notes:** `altium-cruncher notes project.PrjPcb -o <dir>` extracts
+  schematic note objects, text frames, and free text to structured JSON.
+- **Variants:** `altium-cruncher variants list project.PrjPcb --json` shows
+  variants with DNP and parameter changes.
+- **Everything at once:** `altium-cruncher dr project.PrjPcb -o <dir>` writes
+  the full agent-facing design-review bundle (design JSON, document JSON,
+  notes, schematic SVGs, PCB copper SVGs). Large — only when you truly need
+  the whole design or its SVGs.
+
+### Notes
+
+- **Pin identifiers can be alphanumeric** (`C9`, `D8`, `1`, `A1`). Pass them
+  as strings to `--pin`.
+- **Designators come from project-level annotation.** A bare `.SchDoc`
+  inspected via `query sheet` may show empty designators; use
+  `query summary`/`query components` on the parent `.PrjPcb` instead.
+- **Hierarchical designs work** — the netlist resolves nets across sheets,
+  and `query components` reports `sheet` per component so you can scope by
+  sheet.
+- **The summary's `power_and_ground_nets`** is heuristic (named nets touching
+  POWER-type pins, plus GND/VSS substrings). Use `query nets --contains P5V`
+  etc. to find rails it missed.
+
+## Strategy for circuit reasoning
+
+For "explain what this circuit does" type questions, do not dump the full
+design JSON. Instead:
+
+1. `query summary` to learn sheet names and counts.
+2. `query components --sheet <name>` per sheet to see what's on each one.
+3. `query nets` to see all named signals.
+4. `query connections <main IC designator>` to see how the central part is
+   wired.
+5. Pull individual nets with `query nets --name <X>` only when needed.
+
+This keeps your context window small and your answers grounded in actual
+design data rather than guesses from filenames.
+
+## Example session
+
+User: "What does the dongle do? It's in DONGLE_V2_RELEASED_DESIGN_FILES."
+
+```bash
+# 1. Orient yourself
+altium-cruncher query summary DONGLE_V2_RELEASED_DESIGN_FILES/Dongle_PRJ.PrjPcb
+# → 4 sheets (top + tap_off, codec, regulators), 103 parts, 63 nets,
+#   power: P5V0, P3V3_CODEC, P2V5_MIC, P2V5_SPK, GND
+
+# 2. What's on the codec sheet?
+altium-cruncher query components DONGLE_V2_RELEASED_DESIGN_FILES/Dongle_PRJ.PrjPcb \
+    --sheet Dongle_Sheet2_Codec.SchDoc
+# → DA7212-01UM2 (audio codec) + I²C pull-ups + decoupling
+
+# 3. How is the codec wired?
+altium-cruncher query connections U7 \
+    --project DONGLE_V2_RELEASED_DESIGN_FILES/Dongle_PRJ.PrjPcb
+# → SDA/SCL out to J4 with R34/R35 pull-ups, audio I/O to LINE_TAP, etc.
+```
+
+Synthesize that into a circuit explanation. Cite designators and net names so
+the user can verify against the schematic.

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ rack_results/
 **/History/
 **/Project Logs for */
 **/Project Logs For */
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Run `altium-cruncher <command> --help` for command-specific options.
 | `merge` | Merge multiple SchLib or PcbLib files into one library. | Public |
 | `megamaid` | Decompose a PrjPcb into libraries, BOM/PnP, netlist, split/combined document-library JSON dumps, notes JSONC, and embedded assets. | Public |
 | `notes` | Extract schematic note objects, text frames, and free text to structured JSON. | Public |
+| `query` | Query design data as compact JSON on stdout: project summary, filtered components, nets, and pin-level connectivity. | Experimental |
 | `outjob` | Run project OutJob files through Altium Designer. | Public |
 | `variants` | Inspect and edit PrjPcb project variants. | Public |
 | `mco` | Execute Monkey Change Order JSONC operation files. | Experimental |
@@ -134,6 +135,16 @@ parser setup and behavior belong in command modules, including simple commands.
 New commands, features, and external dependencies need explicit justification in
 the commit, PR, or linked plan. Minimize dependencies unless there is a clear
 install, licensing, and maintenance case.
+
+## Claude Code Skill
+
+`.claude/skills/altium-schematic/` is a project-local Claude Code skill that
+teaches Claude to answer questions about Altium designs (components, nets,
+pin-level connectivity, BOM, sheet hierarchy) by driving the `query`, `bom`,
+`notes`, `variants`, and `design` commands. Claude Code loads it automatically
+when a user asks about an Altium design in this workspace; it also works in
+other workspaces where `altium-cruncher` is installed if copied into that
+project's `.claude/skills/` directory.
 
 ## Tests
 

--- a/docs/contracts/command_manifest.a0.json
+++ b/docs/contracts/command_manifest.a0.json
@@ -24,6 +24,7 @@
     {"name": "pnp", "status": "public", "requires_extra": null},
     {"name": "prjpcb", "status": "public", "requires_extra": null},
     {"name": "profiles", "status": "public", "requires_extra": null},
+    {"name": "query", "status": "experimental", "requires_extra": null},
     {"name": "sch-ir", "status": "public", "requires_extra": null},
     {"name": "schdoc", "status": "public", "requires_extra": null},
     {"name": "schlib", "status": "public", "requires_extra": null},

--- a/docs/design/cli/index.html
+++ b/docs/design/cli/index.html
@@ -206,6 +206,12 @@
         <td><code>docs/contracts/mate_config.a0.schema.json</code></td>
         <td>Generate fixture mating-board plans and runnable MCO files.</td>
       </tr>
+      <tr data-command="query" data-design-doc="cli/query.html" data-config-contract="none">
+        <td><code>query</code></td>
+        <td><a href="query.html">query.html</a></td>
+        <td>None</td>
+        <td>Query design data as compact JSON for scripts and agents.</td>
+      </tr>
       <tr data-command="json-dump" data-design-doc="cli/json-dump.html" data-config-contract="none">
         <td><code>json-dump</code></td>
         <td><a href="json-dump.html">json-dump.html</a></td>

--- a/docs/design/cli/query.html
+++ b/docs/design/cli/query.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>query command</title><link rel="stylesheet" href="../styles.css"></head>
+<body data-doc-status="accepted" data-doc-kind="cli-design" data-command="query" data-config-contract="none">
+<main>
+  <nav class="nav"><a href="../index.html">Design Index</a><a href="index.html">CLI</a></nav>
+  <header><p class="status">CLI command design</p><h1>query</h1><p class="lede">Queries Altium design data and prints compact JSON to stdout for scripts and agent workflows.</p></header>
+
+  <section id="purpose"><h2>Purpose</h2><p><code>query</code> answers targeted design questions without generating artifact files. Where <code>design</code> writes a full review bundle to disk, <code>query</code> returns the smallest JSON payload that answers one question — a project overview, a filtered component list, a net list, per-pin connectivity for one designator, or a single-sheet inspection — so scripted consumers and AI agents can load only the relevant slice of design data. The command backs the repository's <code>altium-schematic</code> Claude Code skill and is experimental while its JSON field shapes track the underlying <code>altium-monkey</code> design and netlist JSON.</p></section>
+
+  <section id="usage"><h2>Usage</h2><pre><code>altium-cruncher query summary project.PrjPcb
+altium-cruncher query components --sheet Codec.SchDoc --type ic
+altium-cruncher query components --value-contains 10k --full
+altium-cruncher query nets --contains P5V
+altium-cruncher query nets --name SDA
+altium-cruncher query connections U7 --pin C9
+altium-cruncher query sheet Codec.SchDoc</code></pre></section>
+
+  <section id="arguments"><h2>Arguments</h2><p>Project subcommands (<code>summary</code>, <code>components</code>, <code>nets</code>, <code>connections</code>) accept an optional positional <code>.PrjPcb</code> path or <code>--project</code>; when neither is passed, exactly one <code>.PrjPcb</code> must exist in the current directory, otherwise the command lists candidates and exits nonzero. <code>components</code> filters with <code>--designator</code>, <code>--sheet</code> (full hierarchy path or bare filename), <code>--type</code> (classification type such as <code>ic</code> or <code>resistor</code>), and <code>--value-contains</code>; rows are brief summary fields unless <code>--full</code> is passed. <code>nets</code> lists all nets, narrows with <code>--contains</code>, or returns one net's full terminal detail with <code>--name</code> (case-insensitive exact match). <code>connections</code> takes a required positional designator and an optional <code>--pin</code> identifier; pin identifiers may be alphanumeric (<code>C9</code>) and unknown designators fail with a sample-designator hint. <code>sheet</code> takes one <code>.SchDoc</code> path and needs no project; bare sheets report library references rather than project-annotated designators.</p></section>
+
+  <section id="output"><h2>Output</h2><p>Every subcommand prints exactly one JSON document to stdout and returns exit code 0, or prints a one-line error to stderr and returns exit code 1. Payload schema ids are <code>altium_cruncher.query.summary.a0</code>, <code>altium_cruncher.query.components.a0</code>, <code>altium_cruncher.query.nets.a0</code>, <code>altium_cruncher.query.net_detail.a0</code>, <code>altium_cruncher.query.connections.a0</code>, and <code>altium_cruncher.query.sheet.a0</code>. Component, net, and terminal field shapes come from <code>altium-monkey</code> <code>AltiumDesign.to_json()</code> and netlist JSON and are experimental until promoted. The summary's <code>power_and_ground_nets</code> list is heuristic: named nets with POWER-typed pins plus GND/VSS name matches. Because stdout is a machine-readable payload, the command routes CLI logging handlers to stderr for its duration; <code>--quiet</code>/<code>--verbose</code> still control log verbosity.</p></section>
+
+  <section id="tests"><h2>Tests</h2><p><code>L3_public_workflows</code> runs every subcommand against the Hydroscope fixture project and validates payload schemas, component filtering, net terminal detail, designator connectivity rows, stdout JSON purity, and unknown-designator/net error exits.</p></section>
+</main>
+</body>
+</html>

--- a/docs/design/command-inventory.md
+++ b/docs/design/command-inventory.md
@@ -38,6 +38,7 @@ This inventory records the command set migrated from the private
 | `mate` | beta | unit/CLI/example | Initial beta for Cricket Node-style fixture and debug mating-board workflows. Broader mate modes remain future work. |
 | `clean` | public | `L3_public_workflows` | Keep. Supports explicit non-mutating config generation plus config-driven schematic and PcbLib cleanup. Needs more fixture-backed CLI tests for actual clean application, output/backup behavior, and PcbLib removal rules. |
 | `profiles` | public | unit/CLI | Lists Altium ProgramData profiles and can clean selected extension module state with explicit targeting and dry-run support. |
+| `query` | experimental | `L3_public_workflows` | Prints compact design JSON to stdout for scripts and agent workflows: project summary, filtered component lists, net lists, per-pin connectivity, and single-sheet inspection. Backs the repo `altium-schematic` Claude Code skill. |
 
 The command manifest lives at `docs/contracts/command_manifest.a0.json`. `L99` should
 eventually enforce that every manifest command has help, docs, and behavioral

--- a/src/py/altium_cruncher/_cli.py
+++ b/src/py/altium_cruncher/_cli.py
@@ -98,6 +98,9 @@ from altium_cruncher.altium_cruncher_cmd_profiles import (
 from altium_cruncher.altium_cruncher_cmd_prjpcb import (
     register_parser as register_prjpcb_parser,
 )
+from altium_cruncher.altium_cruncher_cmd_query import (
+    register_parser as register_query_parser,
+)
 from altium_cruncher.altium_cruncher_cmd_sch_ir import (
     register_parser as register_sch_ir_parser,
 )
@@ -310,6 +313,7 @@ def main() -> None:
     register_pnp_parser(command_subparsers)
     register_prjpcb_parser(command_subparsers)
     register_profiles_parser(command_subparsers)
+    register_query_parser(command_subparsers)
     register_sch_ir_parser(command_subparsers)
     register_sch_svg_parser(command_subparsers)
     register_schdoc_parser(command_subparsers)

--- a/src/py/altium_cruncher/altium_cruncher_cmd_query.py
+++ b/src/py/altium_cruncher/altium_cruncher_cmd_query.py
@@ -1,0 +1,572 @@
+"""Query Altium design data as compact JSON for scripts and agents."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from altium_cruncher.altium_cruncher_common import find_prjpcbs_in_cwd
+
+if TYPE_CHECKING:
+    from altium_monkey.altium_design import AltiumDesign
+
+QUERY_SUMMARY_SCHEMA = "altium_cruncher.query.summary.a0"
+QUERY_COMPONENTS_SCHEMA = "altium_cruncher.query.components.a0"
+QUERY_NETS_SCHEMA = "altium_cruncher.query.nets.a0"
+QUERY_NET_DETAIL_SCHEMA = "altium_cruncher.query.net_detail.a0"
+QUERY_CONNECTIONS_SCHEMA = "altium_cruncher.query.connections.a0"
+QUERY_SHEET_SCHEMA = "altium_cruncher.query.sheet.a0"
+
+
+class QueryCommandError(ValueError):
+    """Raised when the query command cannot resolve user input."""
+
+
+def cmd_query(args: argparse.Namespace) -> int:
+    """Dispatch query subcommands and print one JSON payload to stdout."""
+    action = getattr(args, "query_action", None)
+    if action is None:
+        _print_query_error("query requires a subcommand; see `query --help`")
+        return 1
+    _route_logging_to_stderr()
+    try:
+        payload = _QUERY_ACTIONS[action](args)
+    except Exception as exc:
+        _print_query_error(f"query {action} failed: {exc}")
+        return 1
+    print(json.dumps(payload, indent=2, default=str))
+    return 0
+
+
+def _query_summary(args: argparse.Namespace) -> dict[str, object]:
+    """Build the project summary payload."""
+    project_path = _resolve_project_path(args)
+    design = _load_design(project_path)
+    design_json = design.to_json()
+    netlist_json = design.to_netlist().to_json()
+    return {
+        "schema": QUERY_SUMMARY_SCHEMA,
+        "project_file": project_path.name,
+        "current_variant": _current_variant(design),
+        "variants": design.get_variants(),
+        "sheets": _sheet_rows(design_json),
+        "component_count": len(design_json.get("components", [])),
+        "net_count": len(netlist_json.get("nets", [])),
+        "component_type_counts": _component_type_counts(design_json),
+        "power_and_ground_nets": _power_and_ground_nets(netlist_json),
+        "pcb_documents": [path.name for path in design.get_pcbdoc_paths()],
+    }
+
+
+def _query_components(args: argparse.Namespace) -> dict[str, object]:
+    """Build the filtered component list payload."""
+    design = _load_design(_resolve_project_path(args))
+    components = list(design.to_json().get("components", []))
+    components = _filter_components(components, args)
+    if not args.full:
+        components = [_brief_component(component) for component in components]
+    return {
+        "schema": QUERY_COMPONENTS_SCHEMA,
+        "count": len(components),
+        "components": components,
+    }
+
+
+def _query_nets(args: argparse.Namespace) -> dict[str, object]:
+    """Build the net list payload, or one net's full terminal detail."""
+    design = _load_design(_resolve_project_path(args))
+    nets = list(design.to_netlist().to_json().get("nets", []))
+    if args.name:
+        return _net_detail(nets, args.name)
+    if args.contains:
+        needle = args.contains.upper()
+        nets = [net for net in nets if needle in str(net.get("name") or "").upper()]
+    return {
+        "schema": QUERY_NETS_SCHEMA,
+        "count": len(nets),
+        "nets": [_brief_net(net) for net in nets],
+    }
+
+
+def _query_connections(args: argparse.Namespace) -> dict[str, object]:
+    """Build the per-pin connectivity payload for one designator."""
+    design = _load_design(_resolve_project_path(args))
+    design_json = design.to_json()
+    netlist_json = design.to_netlist().to_json()
+
+    comp_to_nets = design_json.get("indexes", {}).get("component_to_nets", {})
+    if args.designator not in comp_to_nets:
+        sample = ", ".join(sorted(comp_to_nets)[:30])
+        raise QueryCommandError(
+            f"designator {args.designator!r} not found; sample designators: {sample}"
+        )
+
+    component = _component_by_designator(design_json, args.designator)
+    pins = _pin_connection_rows(
+        netlist_json,
+        net_names=comp_to_nets[args.designator],
+        designator=args.designator,
+        pin=args.pin,
+    )
+    if args.pin and not pins:
+        raise QueryCommandError(f"pin {args.pin!r} not found on {args.designator}")
+    return {
+        "schema": QUERY_CONNECTIONS_SCHEMA,
+        "designator": args.designator,
+        "value": component.get("value") if component else None,
+        "footprint": component.get("footprint") if component else None,
+        "type": _component_type(component) if component else None,
+        "sheet": _component_sheet(component) if component else None,
+        "pin_count": len(pins),
+        "pins": pins,
+    }
+
+
+def _query_sheet(args: argparse.Namespace) -> dict[str, object]:
+    """Build the single-SchDoc inspection payload."""
+    from altium_monkey.altium_schdoc import AltiumSchDoc
+
+    schdoc_path = Path(args.schdoc_file)
+    if not schdoc_path.is_file():
+        raise FileNotFoundError(f"SchDoc not found: {schdoc_path}")
+    if schdoc_path.suffix.lower() != ".schdoc":
+        raise QueryCommandError(f"expected a .SchDoc file, got: {schdoc_path.name}")
+    schdoc = AltiumSchDoc(str(schdoc_path))
+
+    components = [_sheet_component_row(component) for component in schdoc.components]
+    net_labels = _unique_attr_texts(schdoc.net_labels, "text")
+    ports = _unique_attr_texts(schdoc.ports, "name")
+    sheet_symbols = [_sheet_symbol_row(symbol) for symbol in schdoc.sheet_symbols]
+    return {
+        "schema": QUERY_SHEET_SCHEMA,
+        "filename": schdoc_path.name,
+        "component_count": len(components),
+        "components": components,
+        "net_label_count": len(net_labels),
+        "net_labels": net_labels,
+        "port_count": len(ports),
+        "ports": ports,
+        "sheet_symbol_count": len(sheet_symbols),
+        "sheet_symbols": sheet_symbols,
+    }
+
+
+_QUERY_ACTIONS = {
+    "summary": _query_summary,
+    "components": _query_components,
+    "nets": _query_nets,
+    "connections": _query_connections,
+    "sheet": _query_sheet,
+}
+
+
+def _load_design(project_path: Path) -> "AltiumDesign":
+    """Load an AltiumDesign from a resolved .PrjPcb path."""
+    from altium_monkey.altium_design import AltiumDesign
+
+    return AltiumDesign.from_prjpcb(project_path)
+
+
+def _resolve_project_path(args: argparse.Namespace) -> Path:
+    """Resolve the target project from positional, --project, or CWD scan."""
+    positional = getattr(args, "project_file", None)
+    explicit = getattr(args, "project", None)
+    if positional is not None and explicit is not None:
+        raise QueryCommandError("pass either a project path or --project, not both")
+    selected = explicit if explicit is not None else positional
+    if selected is not None:
+        return _validate_project_path(Path(selected))
+    projects = [project.resolve() for project in find_prjpcbs_in_cwd()]
+    if len(projects) == 1:
+        return projects[0]
+    if not projects:
+        raise QueryCommandError(
+            "No .PrjPcb file found in the current directory; pass a project explicitly."
+        )
+    project_list = "\n".join(f"  {project.name}" for project in projects)
+    raise QueryCommandError(
+        "Multiple .PrjPcb files found in the current directory; pass one explicitly "
+        f"or use --project:\n{project_list}"
+    )
+
+
+def _validate_project_path(path: Path) -> Path:
+    """Validate that a user-supplied project path is an existing .PrjPcb."""
+    project = path.resolve()
+    if project.suffix.lower() != ".prjpcb":
+        raise QueryCommandError(f"Expected a .PrjPcb project, got: {project}")
+    if not project.is_file():
+        raise FileNotFoundError(f"Project not found: {project}")
+    return project
+
+
+def _current_variant(design: "AltiumDesign") -> str | None:
+    """Return the project's current variant name when available."""
+    project = getattr(design, "project", None)
+    if project is None:
+        return None
+    return project.get_current_variant()
+
+
+def _sheet_rows(design_json: dict[str, object]) -> list[dict[str, object]]:
+    """Return sheet filename/title rows with top-level markers."""
+    hierarchy_docs = design_json.get("schematic_hierarchy", {}).get("documents", [])
+    top_level_by_filename = {
+        doc.get("filename"): doc.get("is_top_level") for doc in hierarchy_docs
+    }
+    return [
+        {
+            "filename": sheet.get("filename"),
+            "title": sheet.get("title"),
+            "is_top_level": top_level_by_filename.get(sheet.get("filename")),
+        }
+        for sheet in design_json.get("sheets", [])
+    ]
+
+
+def _component_type_counts(design_json: dict[str, object]) -> dict[str, int]:
+    """Return component counts grouped by classification type."""
+    counts: dict[str, int] = {}
+    for component in design_json.get("components", []):
+        kind = _component_type(component) or "unknown"
+        counts[kind] = counts.get(kind, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _power_and_ground_nets(netlist_json: dict[str, object]) -> list[str]:
+    """Return named nets that look like power or ground rails.
+
+    Heuristic: a named, non-auto-named net counts when any terminal pin is
+    POWER-typed or the net name contains GND or VSS.
+    """
+    names = {
+        str(net["name"])
+        for net in netlist_json.get("nets", [])
+        if net.get("name")
+        and not net.get("auto_named")
+        and (
+            any(
+                terminal.get("pin_type") == "POWER"
+                for terminal in net.get("terminals", [])
+            )
+            or any(token in str(net["name"]).upper() for token in ("GND", "VSS"))
+        )
+    }
+    return sorted(names)
+
+
+def _filter_components(
+    components: list[dict[str, object]],
+    args: argparse.Namespace,
+) -> list[dict[str, object]]:
+    """Apply designator, sheet, type, and value filters to component rows."""
+    return [
+        component
+        for component in components
+        if _component_matches_filters(component, args)
+    ]
+
+
+def _component_matches_filters(
+    component: dict[str, object],
+    args: argparse.Namespace,
+) -> bool:
+    """Return whether one component row passes every requested filter."""
+    if args.designator and component.get("designator") != args.designator:
+        return False
+    if args.sheet and not _component_sheet_matches(component, args.sheet):
+        return False
+    if args.type and (_component_type(component) or "").lower() != args.type.lower():
+        return False
+    if args.value_contains:
+        needle = args.value_contains.lower()
+        return needle in str(component.get("value") or "").lower()
+    return True
+
+
+def _component_sheet_matches(component: dict[str, object], sheet: str) -> bool:
+    """Match a sheet filter against the full hierarchy path or bare filename."""
+    wanted = sheet.lower()
+    owning_sheet = _component_sheet(component)
+    return owning_sheet.lower() == wanted or Path(owning_sheet).name.lower() == wanted
+
+
+def _brief_component(component: dict[str, object]) -> dict[str, object]:
+    """Reduce one component row to agent-friendly summary fields."""
+    classification = component.get("classification", {})
+    return {
+        "designator": component.get("designator"),
+        "value": component.get("value"),
+        "footprint": component.get("footprint"),
+        "type": classification.get("type"),
+        "sheet": _component_sheet(component),
+        "pin_count": classification.get("pin_count"),
+    }
+
+
+def _component_type(component: dict[str, object]) -> str | None:
+    """Return the classification type for one component row."""
+    kind = component.get("classification", {}).get("type")
+    return str(kind) if kind else None
+
+
+def _component_sheet(component: dict[str, object]) -> str:
+    """Return the owning sheet filename for one component row."""
+    return str(component.get("hierarchy", {}).get("sheet", "") or "")
+
+
+def _component_by_designator(
+    design_json: dict[str, object],
+    designator: str,
+) -> dict[str, object] | None:
+    """Return the component row matching a designator, if present."""
+    for component in design_json.get("components", []):
+        if component.get("designator") == designator:
+            return component
+    return None
+
+
+def _net_detail(nets: list[dict[str, object]], name: str) -> dict[str, object]:
+    """Return the full terminal detail payload for one named net."""
+    target = name.upper()
+    matches = [net for net in nets if str(net.get("name") or "").upper() == target]
+    if not matches:
+        raise QueryCommandError(f"no net named: {name}")
+    net = matches[0]
+    return {
+        "schema": QUERY_NET_DETAIL_SCHEMA,
+        "name": net.get("name"),
+        "auto_named": net.get("auto_named"),
+        "source_sheets": net.get("source_sheets"),
+        "terminal_count": len(net.get("terminals", [])),
+        "terminals": net.get("terminals", []),
+    }
+
+
+def _brief_net(net: dict[str, object]) -> dict[str, object]:
+    """Reduce one net row to name, terminal count, and source sheets."""
+    return {
+        "name": net.get("name"),
+        "auto_named": net.get("auto_named"),
+        "terminal_count": len(net.get("terminals", [])),
+        "source_sheets": net.get("source_sheets"),
+    }
+
+
+def _pin_connection_rows(
+    netlist_json: dict[str, object],
+    *,
+    net_names: list[str],
+    designator: str,
+    pin: str | None,
+) -> list[dict[str, object]]:
+    """Return per-pin rows describing what one designator connects to."""
+    nets_by_name = {net.get("name"): net for net in netlist_json.get("nets", [])}
+    rows: list[dict[str, object]] = []
+    for net_name in net_names:
+        net = nets_by_name.get(net_name)
+        if not net:
+            continue
+        terminals = list(net.get("terminals", []))
+        own = [t for t in terminals if t.get("designator") == designator]
+        others = [t for t in terminals if t.get("designator") != designator]
+        for terminal in own:
+            if pin is not None and str(terminal.get("pin")) != str(pin):
+                continue
+            rows.append(
+                {
+                    "pin": terminal.get("pin"),
+                    "pin_name": terminal.get("pin_name"),
+                    "pin_type": terminal.get("pin_type"),
+                    "net": net_name,
+                    "connected_to": [_terminal_row(other) for other in others],
+                }
+            )
+    return rows
+
+
+def _terminal_row(terminal: dict[str, object]) -> dict[str, object]:
+    """Reduce one netlist terminal to designator/pin identification fields."""
+    return {
+        "designator": terminal.get("designator"),
+        "pin": terminal.get("pin"),
+        "pin_name": terminal.get("pin_name"),
+        "pin_type": terminal.get("pin_type"),
+    }
+
+
+def _sheet_component_row(component: object) -> dict[str, object]:
+    """Return library reference and value fields for one SchDoc component."""
+    parameters: dict[str, str] = {}
+    for parameter in getattr(component, "parameters", []) or []:
+        name = getattr(parameter, "name", None)
+        text = getattr(parameter, "text", None)
+        if name and text not in (None, ""):
+            parameters[str(name)] = str(text)
+    return {
+        "lib_reference": getattr(component, "lib_reference", None),
+        "design_item_id": getattr(component, "design_item_id", None),
+        "description": getattr(component, "component_description", None),
+        "value": parameters.get("Value") or parameters.get("Comment"),
+        "manufacturer_part": parameters.get("MP"),
+    }
+
+
+def _sheet_symbol_row(symbol: object) -> dict[str, object]:
+    """Return filename and sheet-name fields for one sheet symbol."""
+    filename = getattr(symbol, "file_name", None)
+    sheet_name = getattr(symbol, "sheet_name", None)
+    return {
+        "filename": str(getattr(filename, "text", filename) or "") or None,
+        "sheet_name": str(getattr(sheet_name, "text", sheet_name) or "") or None,
+    }
+
+
+def _unique_attr_texts(items: object, attribute: str) -> list[str]:
+    """Return sorted unique non-empty attribute strings from parsed records."""
+    return sorted(
+        {
+            str(value)
+            for item in items or []
+            if (value := getattr(item, attribute, None))
+        }
+    )
+
+
+def _route_logging_to_stderr() -> None:
+    """Move stdout log handlers to stderr so stdout stays parseable JSON."""
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, logging.StreamHandler) and handler.stream is sys.stdout:
+            handler.setStream(sys.stderr)
+
+
+def _print_query_error(message: str) -> None:
+    """Print one query command error message to stderr."""
+    print(message, file=sys.stderr)
+
+
+def register_parser(
+    subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    """Register the query command parser."""
+    parser = subparsers.add_parser(
+        "query",
+        help="query design data as compact JSON for scripts and agents",
+        description=(
+            "Query Altium design data and print compact JSON to stdout. "
+            "Subcommands return the smallest payload that answers a typical "
+            "design question: project summary, filtered component lists, net "
+            "lists, per-pin connectivity, and single-sheet inspection. "
+            "When no project is passed, project subcommands auto-detect "
+            "exactly one .PrjPcb in the current directory."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  altium-cruncher query summary project.PrjPcb\n"
+            "  altium-cruncher query components --sheet Codec.SchDoc --type ic\n"
+            "  altium-cruncher query nets --contains P5V\n"
+            "  altium-cruncher query nets --name SDA\n"
+            "  altium-cruncher query connections U7 --pin C9\n"
+            "  altium-cruncher query sheet Codec.SchDoc"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    action_subparsers = parser.add_subparsers(
+        dest="query_action",
+        metavar="<query-action>",
+    )
+
+    summary_parser = action_subparsers.add_parser(
+        "summary",
+        help="project overview: sheets, counts, variants, power nets",
+    )
+    _add_project_arguments(summary_parser)
+
+    components_parser = action_subparsers.add_parser(
+        "components",
+        help="list and filter project components",
+    )
+    components_parser.add_argument(
+        "--designator",
+        help="exact designator match",
+    )
+    components_parser.add_argument(
+        "--sheet",
+        help="filter by owning sheet filename",
+    )
+    components_parser.add_argument(
+        "--type",
+        help="filter by classification type: ic, resistor, capacitor, connector, ...",
+    )
+    components_parser.add_argument(
+        "--value-contains",
+        help="case-insensitive substring match on component value",
+    )
+    components_parser.add_argument(
+        "--full",
+        action="store_true",
+        help="include full component rows instead of brief summary fields",
+    )
+    _add_project_arguments(components_parser)
+
+    nets_parser = action_subparsers.add_parser(
+        "nets",
+        help="list nets, or fetch one net's full terminal detail",
+    )
+    nets_parser.add_argument(
+        "--name",
+        help="exact net name (case-insensitive) for full terminal detail",
+    )
+    nets_parser.add_argument(
+        "--contains",
+        help="case-insensitive substring match on net names",
+    )
+    _add_project_arguments(nets_parser)
+
+    connections_parser = action_subparsers.add_parser(
+        "connections",
+        help="per-pin connectivity for one designator",
+    )
+    connections_parser.add_argument(
+        "designator",
+        help="component designator, for example U7",
+    )
+    connections_parser.add_argument(
+        "--pin",
+        help="restrict output to one pin identifier, for example C9 or 1",
+    )
+    _add_project_arguments(connections_parser)
+
+    sheet_parser = action_subparsers.add_parser(
+        "sheet",
+        help="inspect a single .SchDoc without a project",
+    )
+    sheet_parser.add_argument(
+        "schdoc_file",
+        type=Path,
+        help="SchDoc file to inspect",
+    )
+    sheet_parser.set_defaults(handler=cmd_query)
+
+    parser.set_defaults(handler=cmd_query)
+    return parser
+
+
+def _add_project_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add the shared optional project positional and --project option."""
+    parser.add_argument(
+        "project_file",
+        nargs="?",
+        type=Path,
+        help="PrjPcb file (optional if exactly one PrjPcb in CWD)",
+    )
+    parser.add_argument(
+        "--project",
+        type=Path,
+        help="explicit .PrjPcb project path",
+    )
+    parser.set_defaults(handler=cmd_query)

--- a/tests/L3_public_workflows/STRATUM.toml
+++ b/tests/L3_public_workflows/STRATUM.toml
@@ -125,3 +125,33 @@ oracle_parse = "Parse Altium XML-BOM and PNP-METRIC files from reference_output"
 test_bom_raw_json_covers_altium_xml_oracle_designators = "Validate raw BOM source data against XML-BOM oracle designators"
 test_pnp_json_matches_altium_metric_oracle_core_geometry = "Validate PnP placement geometry against PNP-METRIC CSV"
 test_jlc_command_writes_paired_outputs_for_primary_fixtures = "Generate paired JLC BOM/CPL outputs for primary BOM/PnP fixtures"
+
+[[subtests]]
+id = "L3_005"
+file = "test_L3_005_query_workflow.py"
+name = "Query Workflow"
+description = "Run every query subcommand against the Hydroscope fixture and validate stdout JSON payloads"
+concerns = ["cli", "contracts"]
+test_case_type = "reference"
+test_cases = "../../tests/assets/projects/hydroscope/input"
+
+[subtests.code_under_test]
+module = "altium_cruncher.altium_cruncher_cmd_query"
+
+[subtests.objectives]
+summary_payload = "Summary reports sheets, counts, variants, and heuristic power nets"
+filtered_payloads = "Component, net, and connection payloads respect filters and schemas"
+stdout_purity = "stdout stays one parseable JSON payload even with verbose logging"
+error_contract = "Unknown designators and nets exit 1 with stderr hints"
+
+[subtests.approach]
+subprocess_cli = "Invoke the public query CLI through the current Python environment"
+
+[subtests.test_functions]
+test_query_summary_reports_hydroscope_overview = "Summary payload reports sheets, counts, variants, and power nets"
+test_query_components_filters_by_type_and_sheet = "Component rows respect type/sheet filters and brief default fields"
+test_query_nets_listing_and_named_terminal_detail = "Net listing filters by substring and named nets return terminals"
+test_query_connections_reports_designator_pin_rows = "Connections payload reports per-pin nets and connected terminals"
+test_query_sheet_inspects_bare_schdoc = "Sheet payload inspects one SchDoc without needing a project"
+test_query_errors_exit_nonzero_with_stderr_hint = "Unknown designators and nets exit 1 with a stderr message"
+test_query_stdout_stays_parseable_with_verbose_logging = "Verbose logging routes to stderr so stdout remains one JSON payload"

--- a/tests/L3_public_workflows/test_L3_005_query_workflow.py
+++ b/tests/L3_public_workflows/test_L3_005_query_workflow.py
@@ -1,0 +1,182 @@
+"""Fixture-backed CLI workflow tests for the query command."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _project_root() -> Path:
+    """Find the repository root from this test file."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError("Could not locate repository root")
+
+
+PACKAGE_ROOT = _project_root()
+HYDROSCOPE_DIR = PACKAGE_ROOT / "tests" / "assets" / "projects" / "hydroscope" / "input"
+HYDROSCOPE_PROJECT = HYDROSCOPE_DIR / "Hydroscope.PrjPcb"
+HYDROSCOPE_SCHDOC = HYDROSCOPE_DIR / "CPU.SchDoc"
+
+
+def _run_query(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run one query CLI invocation through the current Python environment."""
+    return subprocess.run(
+        [sys.executable, "-m", "altium_cruncher", "query", *args],
+        cwd=PACKAGE_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def _run_query_json(*args: str) -> dict[str, object]:
+    """Run one query invocation and parse its stdout as one JSON payload."""
+    completed = _run_query(*args)
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    return json.loads(completed.stdout)
+
+
+def test_query_summary_reports_hydroscope_overview() -> None:
+    """Summary payload reports sheets, counts, variants, and power nets."""
+    payload = _run_query_json("summary", str(HYDROSCOPE_PROJECT))
+
+    assert payload["schema"] == "altium_cruncher.query.summary.a0"
+    assert payload["project_file"] == "Hydroscope.PrjPcb"
+    assert payload["variants"] == ["A", "B"]
+    assert payload["component_count"] >= 100
+    assert payload["net_count"] >= 100
+    sheet_files = {sheet["filename"] for sheet in payload["sheets"]}
+    assert "CPU.SchDoc" in sheet_files
+    top_level = [s for s in payload["sheets"] if s["is_top_level"]]
+    assert [s["filename"] for s in top_level] == ["TOP_LEVEL.SchDoc"]
+    assert "GND" in payload["power_and_ground_nets"]
+
+
+def test_query_components_filters_by_type_and_sheet() -> None:
+    """Component rows respect type/sheet filters and brief default fields."""
+    payload = _run_query_json(
+        "components",
+        str(HYDROSCOPE_PROJECT),
+        "--type",
+        "ic",
+        "--sheet",
+        "CPU.SchDoc",
+    )
+
+    assert payload["schema"] == "altium_cruncher.query.components.a0"
+    components = payload["components"]
+    assert payload["count"] == len(components) > 0
+    for component in components:
+        assert component["type"] == "ic"
+        assert Path(component["sheet"]).name == "CPU.SchDoc"
+        assert set(component) == {
+            "designator",
+            "value",
+            "footprint",
+            "type",
+            "sheet",
+            "pin_count",
+        }
+
+
+def test_query_nets_listing_and_named_terminal_detail() -> None:
+    """Net listing filters by substring and named nets return terminals."""
+    listing = _run_query_json(
+        "nets",
+        str(HYDROSCOPE_PROJECT),
+        "--contains",
+        "GND",
+    )
+    assert listing["schema"] == "altium_cruncher.query.nets.a0"
+    assert any(net["name"] == "GND" for net in listing["nets"])
+
+    detail = _run_query_json("nets", str(HYDROSCOPE_PROJECT), "--name", "gnd")
+    assert detail["schema"] == "altium_cruncher.query.net_detail.a0"
+    assert detail["name"] == "GND"
+    assert detail["terminal_count"] == len(detail["terminals"]) > 50
+    assert {"designator", "pin"} <= set(detail["terminals"][0])
+
+
+def test_query_connections_reports_designator_pin_rows() -> None:
+    """Connections payload reports per-pin nets and connected terminals."""
+    payload = _run_query_json(
+        "connections",
+        "U4",
+        "--project",
+        str(HYDROSCOPE_PROJECT),
+    )
+
+    assert payload["schema"] == "altium_cruncher.query.connections.a0"
+    assert payload["designator"] == "U4"
+    assert payload["sheet"] == "CPU.SchDoc"
+    assert payload["pin_count"] == len(payload["pins"]) > 0
+    reset_rows = [pin for pin in payload["pins"] if pin["net"] == "RST"]
+    assert reset_rows
+    connected = {
+        (terminal["designator"], terminal["pin"])
+        for terminal in reset_rows[0]["connected_to"]
+    }
+    assert ("U3", "48") in connected
+
+
+def test_query_sheet_inspects_bare_schdoc() -> None:
+    """Sheet payload inspects one SchDoc without needing a project."""
+    payload = _run_query_json("sheet", str(HYDROSCOPE_SCHDOC))
+
+    assert payload["schema"] == "altium_cruncher.query.sheet.a0"
+    assert payload["filename"] == "CPU.SchDoc"
+    assert payload["component_count"] == len(payload["components"]) > 0
+    assert payload["net_label_count"] == len(payload["net_labels"])
+
+
+def test_query_errors_exit_nonzero_with_stderr_hint() -> None:
+    """Unknown designators and nets exit 1 with a stderr message."""
+    unknown_designator = _run_query(
+        "connections",
+        "ZZ99",
+        "--project",
+        str(HYDROSCOPE_PROJECT),
+    )
+    assert unknown_designator.returncode == 1
+    assert unknown_designator.stdout == ""
+    assert "ZZ99" in unknown_designator.stderr
+
+    unknown_net = _run_query(
+        "nets",
+        str(HYDROSCOPE_PROJECT),
+        "--name",
+        "NO_SUCH_NET",
+    )
+    assert unknown_net.returncode == 1
+    assert "NO_SUCH_NET" in unknown_net.stderr
+
+
+def test_query_stdout_stays_parseable_with_verbose_logging() -> None:
+    """Verbose logging routes to stderr so stdout remains one JSON payload."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "altium_cruncher",
+            "--verbose",
+            "query",
+            "summary",
+            str(HYDROSCOPE_PROJECT),
+        ],
+        cwd=PACKAGE_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["schema"] == "altium_cruncher.query.summary.a0"


### PR DESCRIPTION
## Summary

Retargets the Claude Code skill from wavenumber-eng/altium_monkey#1 to this repo, built around the CLI as requested there, with the skill's subcommands added as a new `query` command.

- Adds an experimental `query` command that prints compact design JSON to stdout for scripts and agent workflows:
  - `query summary` — sheets, component/net counts, type breakdown, heuristic power/ground nets, variants, PCB documents
  - `query components` — filtered list (`--designator`/`--sheet`/`--type`/`--value-contains`), brief rows by default, `--full` for everything
  - `query nets` — net listing, `--contains` substring filter, or full terminal detail with `--name`
  - `query connections DESIGNATOR [--pin PIN]` — per-pin connectivity built from the design JSON `component_to_nets` index plus the netlist
  - `query sheet FILE.SchDoc` — single-sheet inspection without a project
- Project subcommands resolve the target from a positional path, `--project`, or a single `.PrjPcb` in the CWD, following the `variants` convention.
- stdout carries exactly one JSON payload per invocation; the command routes CLI logging handlers to stderr for its duration so `--verbose` cannot corrupt machine-readable output. Errors exit 1 with a one-line stderr hint (unknown designators include a sample-designator list).
- Adds the project-local Claude Code skill at `.claude/skills/altium-schematic/` teaching Claude to answer Altium design questions by driving `query`, `bom`, `notes`, `variants`, and `design` rather than guessing from filenames.

## Justification

`design`/`json-dump` emit full-design artifacts to disk; agent and scripting workflows need small, targeted payloads on stdout so only the relevant slice of design data enters an LLM context window. No new dependencies; the command uses the existing `altium-monkey` design/netlist JSON. Field shapes track `altium-monkey`, hence the `experimental` manifest status.

## Compliance

- Command module `altium_cruncher_cmd_query.py`; top-level CLI stays an orchestrator.
- Manifest entry (experimental) in `command_manifest.a0.json`; payload schema ids `altium_cruncher.query.*.a0`.
- Design doc `docs/design/cli/query.html` plus CLI design index row; README command row and skill section; `command-inventory.md` row.
- New `L3_005` fixture-backed workflow tests (Hydroscope) covering every subcommand, filter behavior, stdout JSON purity under `--verbose`, and error exit codes.
- `.gitignore` entry for `.claude/settings.local.json`.

## Test plan

- `uv run --extra test rack run --all`: 12/12 subtests, 74 passed, 1 pre-existing skip (native megamaid parity).
- `ruff check .` passes; `py_signoff` has zero findings.
- Manual smoke test of every subcommand and error path against a real 4-sheet hierarchical audio-codec project (103 components / 63 nets), including alphanumeric BGA-style pin ids (`query connections U7 --pin C9`) and variant reporting.

Signoff: Russell Brown (russelldb). Implementation note: Claude Code materially assisted with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnFjWVDP7XWFdDFiYvCF3D