### PR TITLE
release: altium-cruncher 2026.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026.7.9
+
+- Consume `altium-monkey>=2026.7.9`, including the OLE reader root mini
+  stream cache that makes reading many small streams from large
+  SchLib/PcbLib/SchDoc/PcbDoc files substantially faster (a reporter measured
+  a library load going from ~17s to ~4s).
+- Downstream schematic output picks up the Altium Monkey arc radius
+  round-trip fixes: fractional radii are preserved on arcs, elliptical arcs,
+  and pie charts, and authored whole radii such as exactly 100.0 mils no
+  longer serialize as omitted and reparse as 0.
+- Schematic IR `font_resolution` diagnostics are emitted in canonical sorted
+  order for stable downstream diffing.
+
 ## 2026.7.7
 
 - Consume `altium-monkey>=2026.7.7`, including the schematic font resolution

--- a/docs/releases/2026-07-09.md
+++ b/docs/releases/2026-07-09.md
@@ -1,0 +1,34 @@
+# Release Notes - 2026-07-09
+
+These notes describe the 2026-07-09 public release candidate for
+`altium-cruncher` package version `2026.7.9`.
+
+## Release Status
+
+This release is a dependency refresh that consumes the Altium Monkey OLE
+reader performance work and schematic arc radius round-trip fixes. There are
+no cruncher-side feature changes.
+
+Please report issues with the exact command, version output, expected behavior,
+actual behavior, and a public-safe reproduction fixture when possible.
+
+## Highlights
+
+- The package consumes `altium-monkey>=2026.7.9`.
+- The package continues to consume pinned `wn-geometer==2026.6.10`.
+- Reading many small streams from large SchLib/PcbLib/SchDoc/PcbDoc files is
+  substantially faster from the new Altium Monkey OLE root mini stream cache;
+  the reporter of the upstream issue measured a library load going from ~17s
+  to ~4s.
+- Schematic arc radius round-trip fixes: fractional radii are preserved on
+  arcs, elliptical arcs, and pie charts, and authored whole radii such as
+  exactly 100.0 mils no longer serialize as omitted and reparse as 0.
+- Schematic IR `font_resolution` diagnostics are emitted in canonical sorted
+  order for stable downstream diffing.
+
+## Known Caveats
+
+- Local Altium launch, OutJob execution, and profile cleanup still require
+  Windows with Altium Designer/profile folders present. Discovery/list commands
+  are safe to exercise on Linux/macOS and return empty results when no local
+  Altium state exists.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "altium-cruncher"
-version = "2026.7.7"
+version = "2026.7.9"
 description = "Cross-platform Altium CLI utilities built on public altium-monkey"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -9,7 +9,7 @@ authors = [
     { name = "Wavenumber LLC" },
 ]
 dependencies = [
-    "altium-monkey>=2026.7.7",
+    "altium-monkey>=2026.7.9",
     "colorama>=0.4.6",
     "easyeda-monkey>=2026.5.26",
     "json-with-comments>=1.2.10",

--- a/src/py/altium_cruncher/_version.py
+++ b/src/py/altium_cruncher/_version.py
@@ -8,7 +8,7 @@ from datetime import date
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 
-__version__ = "2026.7.7"
+__version__ = "2026.7.9"
 
 _DISTRIBUTION_NAME = "altium-cruncher"
 _CONTROLLED_DEPENDENCIES = (

--- a/tests/L99_signoff/test_L99_001_release_signoff.py
+++ b/tests/L99_signoff/test_L99_001_release_signoff.py
@@ -23,15 +23,15 @@ def _project_root() -> Path:
 
 
 PACKAGE_ROOT = _project_root()
-EXPECTED_VERSION = "2026.7.7"
-EXPECTED_RELEASE_DATE = date(2026, 7, 7)
-EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-07-07.md"
+EXPECTED_VERSION = "2026.7.9"
+EXPECTED_RELEASE_DATE = date(2026, 7, 9)
+EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-07-09.md"
 CONTROLLED_DEPENDENCY_REQUIREMENTS = {
-    "altium-monkey": ">=2026.7.7",
+    "altium-monkey": ">=2026.7.9",
     "wn-geometer": "==2026.6.10",
 }
 MINIMUM_CONTROLLED_DEPENDENCIES = {
-    "altium-monkey": "2026.7.7",
+    "altium-monkey": "2026.7.9",
 }
 EXACT_CONTROLLED_DEPENDENCIES = {
     "wn-geometer": "2026.6.10",
@@ -49,7 +49,7 @@ def test_version_contract_matches_date_based_release() -> None:
     assert (version.major, version.minor, version.patch, version.build) == (
         2026,
         7,
-        7,
+        9,
         None,
     )
     assert version.release_date == EXPECTED_RELEASE_DATE

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.12.*"
 
 [[package]]
 name = "altium-cruncher"
-version = "2026.7.7"
+version = "2026.7.9"
 source = { editable = "." }
 dependencies = [
     { name = "altium-monkey" },
@@ -40,7 +40,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "altium-monkey", specifier = ">=2026.7.7" },
+    { name = "altium-monkey", specifier = ">=2026.7.9" },
     { name = "build", marker = "extra == 'test'", specifier = ">=1.2.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "easyeda-monkey", specifier = ">=2026.5.26" },
@@ -70,7 +70,7 @@ dev = [
 
 [[package]]
 name = "altium-monkey"
-version = "2026.7.7"
+version = "2026.7.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "freetype-py" },
@@ -80,9 +80,9 @@ dependencies = [
     { name = "uharfbuzz" },
     { name = "wn-geometer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/a3/249b696deb79d23266132176fb676fd09595c2a7b2ce4a8b88dbd84d4053/altium_monkey-2026.7.7.tar.gz", hash = "sha256:1beee99291c185dae6773715961c5e72e1f34820c24ccefab9db42263ebfc37b", size = 4135171, upload-time = "2026-07-07T17:35:35.127Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/40/7fdc918d1731928252dd8536642724ea40a72b5d0f0a19fcf891c4e9b326/altium_monkey-2026.7.9.tar.gz", hash = "sha256:2567706c4ea1cf2c76bc47695b21eae67a6ea544c88d2c378daa43e8982c26f2", size = 4135780, upload-time = "2026-07-09T17:40:28.387Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/d5/c5eb64491632303c2a653c51d11cf4970e4e3f7f72712178ff941400e445/altium_monkey-2026.7.7-py3-none-any.whl", hash = "sha256:631def2774737301b0f9e360d4540c581d5ebea0aa4ae884c96d6a84f734eb96", size = 4225683, upload-time = "2026-07-07T17:35:33.122Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/90/752a795a7a059a799ad1e49913c40b2afa4d0e8a68342b7c088010c238eb/altium_monkey-2026.7.9-py3-none-any.whl", hash = "sha256:6f2782f4d41c268885b52cab631d177a6570ba4089481b576fb1747f8af97989", size = 4226623, upload-time = "2026-07-09T17:40:26.466Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Linked issue: #26

## Summary
- bump altium-cruncher to 2026.7.9 and require altium-monkey>=2026.7.9
- consume the altium-monkey OLE reader root mini stream cache, making reads of many small streams from large SchLib/PcbLib/SchDoc/PcbDoc files substantially faster
- consume the schematic arc radius round-trip fixes (fraction preservation on arcs, elliptical arcs, and pie charts; authored 100.0-mil whole radii no longer serialize as omitted and reparse as 0) and canonical sorted font_resolution diagnostics
- update CHANGELOG, add docs/releases/2026-07-09.md, refresh L99 signoff contracts

## Validation
- uv sync --extra test
- uv run --extra test rack run --all (67 passed, 0 failed, 1 skipped)
- uv run --extra test python -m build
- uv run --extra test twine check dist/* (both PASSED)
- uv run --extra test python tests/support_scripts/install_test.py (passed)

## Notes
- altium-monkey 2026.7.9 is published to PyPI.

Human signoff: @ehughes