### PR TITLE
release: publish altium-cruncher 2026.7.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026.7.29
+
+- Consume pinned `altium-monkey==2026.7.29`, including the stable project-level schematic compiler, `design.a2` physical-page contract, physical SVG/IR rendering, and net-name alias/name-source provenance.
+- `design`, `design-review`, and `dr` workflows now emit one schematic SVG/IR per compiled physical page for repeated/channel projects instead of treating logical SchDoc pages as unique review pages.
+- Add downstream multichannel DR coverage using `node_test_array` to verify `physical_pages`, `compiled_page_id`, resolved physical designators, and `physical_page_id|svg_id` component lookup metadata.
+- Preserve DNP/fitted state from the compiled design in DR schematic SVG metadata for variant-aware review tools.
+
 ## 2026.7.9
 
 - Consume `altium-monkey>=2026.7.9`, including the OLE reader root mini

--- a/docs/contracts/command_manifest.a0.json
+++ b/docs/contracts/command_manifest.a0.json
@@ -1,36 +1,222 @@
 {
-  "schema": "altium_cruncher.command_manifest.a0",
+  "schema": "wn_dev_std.command_manifest.a0",
   "commands": [
-    {"name": "bom", "status": "public", "requires_extra": null},
-    {"name": "clean", "status": "public", "requires_extra": null},
-    {"name": "design", "status": "public", "requires_extra": null},
-    {"name": "easyeda-import", "status": "public", "requires_extra": null},
-    {"name": "extract", "status": "public", "requires_extra": null},
-    {"name": "installs", "status": "public", "requires_extra": null},
-    {"name": "jlc", "status": "public", "requires_extra": null},
-    {"name": "json-dump", "status": "experimental", "requires_extra": null},
-    {"name": "launch", "status": "public", "requires_extra": null},
-    {"name": "libraries", "status": "public", "requires_extra": null},
-    {"name": "mate", "status": "experimental", "requires_extra": null},
-    {"name": "mco", "status": "experimental", "requires_extra": null},
-    {"name": "megamaid", "status": "public", "requires_extra": null},
-    {"name": "merge", "status": "public", "requires_extra": null},
-    {"name": "notes", "status": "public", "requires_extra": null},
-    {"name": "outjob", "status": "public", "requires_extra": null},
-    {"name": "pcb-layer-step", "status": "public", "requires_extra": null},
-    {"name": "pcbdoc", "status": "public", "requires_extra": null},
-    {"name": "pcblib", "status": "public", "requires_extra": null},
-    {"name": "pcb-svg", "status": "public", "requires_extra": null},
-    {"name": "pnp", "status": "public", "requires_extra": null},
-    {"name": "prjpcb", "status": "public", "requires_extra": null},
-    {"name": "profiles", "status": "public", "requires_extra": null},
-    {"name": "sch-ir", "status": "public", "requires_extra": null},
-    {"name": "schdoc", "status": "public", "requires_extra": null},
-    {"name": "schlib", "status": "public", "requires_extra": null},
-    {"name": "sch-svg", "status": "public", "requires_extra": null},
-    {"name": "split", "status": "public", "requires_extra": null},
-    {"name": "svg", "status": "public", "requires_extra": null},
-    {"name": "variants", "status": "public", "requires_extra": null},
-    {"name": "version", "status": "public", "requires_extra": null}
+    {
+      "name": "bom",
+      "status": "public",
+      "design_doc": "docs/design/cli/bom.html",
+      "summary": "Run the altium-cruncher bom command.",
+      "surface_ref": "docs/design/cli/bom.html"
+    },
+    {
+      "name": "clean",
+      "status": "public",
+      "design_doc": "docs/design/cli/clean.html",
+      "summary": "Run the altium-cruncher clean command.",
+      "surface_ref": "docs/design/cli/clean.html"
+    },
+    {
+      "name": "design",
+      "status": "public",
+      "design_doc": "docs/design/cli/design.html",
+      "summary": "Run the altium-cruncher design command.",
+      "surface_ref": "docs/design/cli/design.html"
+    },
+    {
+      "name": "easyeda-import",
+      "status": "public",
+      "design_doc": "docs/design/cli/easyeda-import.html",
+      "summary": "Run the altium-cruncher easyeda-import command.",
+      "surface_ref": "docs/design/cli/easyeda-import.html"
+    },
+    {
+      "name": "extract",
+      "status": "public",
+      "design_doc": "docs/design/cli/extract.html",
+      "summary": "Run the altium-cruncher extract command.",
+      "surface_ref": "docs/design/cli/extract.html"
+    },
+    {
+      "name": "installs",
+      "status": "public",
+      "design_doc": "docs/design/cli/installs.html",
+      "summary": "Run the altium-cruncher installs command.",
+      "surface_ref": "docs/design/cli/installs.html"
+    },
+    {
+      "name": "jlc",
+      "status": "public",
+      "design_doc": "docs/design/cli/jlc.html",
+      "summary": "Run the altium-cruncher jlc command.",
+      "surface_ref": "docs/design/cli/jlc.html"
+    },
+    {
+      "name": "json-dump",
+      "status": "experimental",
+      "design_doc": "docs/design/cli/json-dump.html",
+      "summary": "Run the altium-cruncher json-dump command.",
+      "surface_ref": "docs/design/cli/json-dump.html"
+    },
+    {
+      "name": "launch",
+      "status": "public",
+      "design_doc": "docs/design/cli/launch.html",
+      "summary": "Run the altium-cruncher launch command.",
+      "surface_ref": "docs/design/cli/launch.html"
+    },
+    {
+      "name": "libraries",
+      "status": "public",
+      "design_doc": "docs/design/cli/libraries.html",
+      "summary": "Run the altium-cruncher libraries command.",
+      "surface_ref": "docs/design/cli/libraries.html"
+    },
+    {
+      "name": "mate",
+      "status": "experimental",
+      "design_doc": "docs/design/cli/mate.html",
+      "summary": "Run the altium-cruncher mate command.",
+      "surface_ref": "docs/design/cli/mate.html"
+    },
+    {
+      "name": "mco",
+      "status": "experimental",
+      "design_doc": "docs/design/cli/mco.html",
+      "summary": "Run the altium-cruncher mco command.",
+      "surface_ref": "docs/design/cli/mco.html"
+    },
+    {
+      "name": "megamaid",
+      "status": "public",
+      "design_doc": "docs/design/cli/megamaid.html",
+      "summary": "Run the altium-cruncher megamaid command.",
+      "surface_ref": "docs/design/cli/megamaid.html"
+    },
+    {
+      "name": "merge",
+      "status": "public",
+      "design_doc": "docs/design/cli/merge.html",
+      "summary": "Run the altium-cruncher merge command.",
+      "surface_ref": "docs/design/cli/merge.html"
+    },
+    {
+      "name": "notes",
+      "status": "public",
+      "design_doc": "docs/design/cli/notes.html",
+      "summary": "Run the altium-cruncher notes command.",
+      "surface_ref": "docs/design/cli/notes.html"
+    },
+    {
+      "name": "outjob",
+      "status": "public",
+      "design_doc": "docs/design/cli/outjob.html",
+      "summary": "Run the altium-cruncher outjob command.",
+      "surface_ref": "docs/design/cli/outjob.html"
+    },
+    {
+      "name": "pcb-layer-step",
+      "status": "public",
+      "design_doc": "docs/design/cli/pcb-layer-step.html",
+      "summary": "Run the altium-cruncher pcb-layer-step command.",
+      "surface_ref": "docs/design/cli/pcb-layer-step.html"
+    },
+    {
+      "name": "pcbdoc",
+      "status": "public",
+      "design_doc": "docs/design/cli/pcbdoc.html",
+      "summary": "Run the altium-cruncher pcbdoc command.",
+      "surface_ref": "docs/design/cli/pcbdoc.html"
+    },
+    {
+      "name": "pcblib",
+      "status": "public",
+      "design_doc": "docs/design/cli/pcblib.html",
+      "summary": "Run the altium-cruncher pcblib command.",
+      "surface_ref": "docs/design/cli/pcblib.html"
+    },
+    {
+      "name": "pcb-svg",
+      "status": "public",
+      "design_doc": "docs/design/cli/pcb-svg.html",
+      "summary": "Run the altium-cruncher pcb-svg command.",
+      "surface_ref": "docs/design/cli/pcb-svg.html"
+    },
+    {
+      "name": "pnp",
+      "status": "public",
+      "design_doc": "docs/design/cli/pnp.html",
+      "summary": "Run the altium-cruncher pnp command.",
+      "surface_ref": "docs/design/cli/pnp.html"
+    },
+    {
+      "name": "prjpcb",
+      "status": "public",
+      "design_doc": "docs/design/cli/prjpcb.html",
+      "summary": "Run the altium-cruncher prjpcb command.",
+      "surface_ref": "docs/design/cli/prjpcb.html"
+    },
+    {
+      "name": "profiles",
+      "status": "public",
+      "design_doc": "docs/design/cli/profiles.html",
+      "summary": "Run the altium-cruncher profiles command.",
+      "surface_ref": "docs/design/cli/profiles.html"
+    },
+    {
+      "name": "sch-ir",
+      "status": "public",
+      "design_doc": "docs/design/cli/sch-ir.html",
+      "summary": "Run the altium-cruncher sch-ir command.",
+      "surface_ref": "docs/design/cli/sch-ir.html"
+    },
+    {
+      "name": "schdoc",
+      "status": "public",
+      "design_doc": "docs/design/cli/schdoc.html",
+      "summary": "Run the altium-cruncher schdoc command.",
+      "surface_ref": "docs/design/cli/schdoc.html"
+    },
+    {
+      "name": "schlib",
+      "status": "public",
+      "design_doc": "docs/design/cli/schlib.html",
+      "summary": "Run the altium-cruncher schlib command.",
+      "surface_ref": "docs/design/cli/schlib.html"
+    },
+    {
+      "name": "sch-svg",
+      "status": "public",
+      "design_doc": "docs/design/cli/sch-svg.html",
+      "summary": "Run the altium-cruncher sch-svg command.",
+      "surface_ref": "docs/design/cli/sch-svg.html"
+    },
+    {
+      "name": "split",
+      "status": "public",
+      "design_doc": "docs/design/cli/split.html",
+      "summary": "Run the altium-cruncher split command.",
+      "surface_ref": "docs/design/cli/split.html"
+    },
+    {
+      "name": "svg",
+      "status": "public",
+      "design_doc": "docs/design/cli/svg.html",
+      "summary": "Run the altium-cruncher svg command.",
+      "surface_ref": "docs/design/cli/svg.html"
+    },
+    {
+      "name": "variants",
+      "status": "public",
+      "design_doc": "docs/design/cli/variants.html",
+      "summary": "Run the altium-cruncher variants command.",
+      "surface_ref": "docs/design/cli/variants.html"
+    },
+    {
+      "name": "version",
+      "status": "public",
+      "design_doc": "docs/design/cli/version.html",
+      "summary": "Run the altium-cruncher version command.",
+      "surface_ref": "docs/design/cli/version.html"
+    }
   ]
 }

--- a/docs/design/command-inventory.md
+++ b/docs/design/command-inventory.md
@@ -172,6 +172,16 @@ Design review notes:
   SchDoc/PcbDoc JSON from `json-dump` under `json/schdoc/` and `json/pcbdoc/`,
   enriched schematic SVGs under `sch/`, and PCB layer SVGs where a board
   exists;
+- `.PrjPcb` inputs must use the compiled `AltiumDesign` physical-page view by
+  default: `sch/` contains resolved physical schematic SVGs, `sch-ir/` contains
+  matching physical IR JSON, and manifest entries include `compiled_page_id`;
+- SVG review links must prefer `physical_page_id|svg_id` through
+  `indexes.physical_svg_to_components` for repeated/channel-safe lookup, while
+  `indexes.svg_to_component` remains a scalar convenience only when
+  unambiguous;
+- the generated README must explain compiled-vs-logical schematic views,
+  `physical_pages`, net `aliases`/`name_sources`, and how graphical SVG ids join
+  back to physical designators and nets;
 - PCB layer SVGs use the default `pcb-svg` layer-output shape under
   `pcb/layers/`, but limit physical layer outputs to copper layers, including
   used inner copper layers;

--- a/docs/plans/altium-cruncher-gui-config-infrastructure/plan.md
+++ b/docs/plans/altium-cruncher-gui-config-infrastructure/plan.md
@@ -1,0 +1,391 @@
++++
+type = "plan"
+id = "altium-cruncher-gui-config-infrastructure"
+status = "active"
+created = "2026-07-16"
+
+[[steps]]
+id = "capture-current-state"
+title = "Capture current research findings and planning context"
+status = "done"
+
+[[steps]]
+id = "define-first-target-application"
+title = "Define the first target application requirements"
+status = "active"
+depends_on = ["capture-current-state"]
+
+[[steps]]
+id = "settle-minimum-infrastructure"
+title = "Settle the minimum daemon, contract, and generated-type infrastructure"
+status = "pending"
+depends_on = ["define-first-target-application"]
+
+[[steps]]
+id = "pilot-target-application"
+title = "Implement the first target application against the shared infrastructure"
+status = "pending"
+depends_on = ["settle-minimum-infrastructure"]
+
+[[steps]]
+id = "promote-durable-docs"
+title = "Promote stable outcomes into durable design docs, ADRs, and contracts"
+status = "pending"
+depends_on = ["pilot-target-application"]
+
+[[steps]]
+id = "design-doc-intent-audit"
+title = "Audit design docs, ADRs, and requirements against implementation"
+status = "pending"
+depends_on = ["promote-durable-docs"]
+
+[[steps]]
+id = "test-runtime-impact-audit"
+title = "Audit new test runtime impact"
+status = "pending"
+depends_on = ["pilot-target-application"]
+
+[[steps]]
+id = "external-review"
+title = "Obtain independent external review"
+status = "pending"
+depends_on = ["design-doc-intent-audit", "test-runtime-impact-audit"]
+
+[[exit_criteria]]
+id = "signoff"
+title = "Focused signoff passes"
+status = "pending"
+
+[[exit_criteria]]
+id = "first-target-application-defined"
+title = "The first target application requirements and acceptance criteria are defined"
+status = "pending"
+
+[[exit_criteria]]
+id = "minimum-infrastructure-settled"
+title = "The minimum daemon, API contract, config contract, and generated-type rules are settled"
+status = "pending"
+
+[[exit_criteria]]
+id = "headless-cli-preserved"
+title = "Saved GUI-edited configs can be consumed by headless CLI flows without GUI-only state"
+status = "pending"
+
+[[exit_criteria]]
+id = "design-doc-intent-audit"
+title = "Design docs, ADRs, and requirements match implementation"
+status = "pending"
+
+[[exit_criteria]]
+id = "test-runtime-impact-audit"
+title = "New tests are listed and runtime impact is reviewed"
+status = "pending"
+
+[[exit_criteria]]
+id = "external-review"
+title = "Independent external review is complete"
+status = "pending"
++++
+
+# Altium Cruncher GUI Config Infrastructure
+
+## Purpose
+
+This plan captures the current research and direction for adding a lightweight
+GUI/server infrastructure to `altium-cruncher`. The immediate goal is not to
+design one universal UI for every command. The goal is to establish the minimum
+rules, contracts, and hygiene needed so future config editors and preview tools
+can share a reliable process-level bridge to `altium-cruncher`.
+
+The first target application is still pending. Current expectation is that the
+pilot will be related to SVG or assembly documentation views, because those
+configs are already complex and upcoming documentation-generator work needs an
+interactive editor with live preview.
+
+## Current Research Snapshot
+
+### Lib Cruncher Cleaner Integration
+
+`appz/lib_cruncher` currently performs library asset import and cleaning in
+Python process, not by spawning the `altium-cruncher` CLI.
+
+Important current behavior:
+
+- Symbols and footprints pass through `altium-cruncher` Python package helpers
+  in-process.
+- Lib Cruncher still uses direct `altium_monkey` APIs for low-level loading,
+  extraction, copying, and preview rendering.
+- Symbol import has bespoke pre-clean selection/copy behavior before invoking
+  the `altium-cruncher` schematic cleaner profile.
+- Footprint import copies the selected footprint with `altium_monkey`, then
+  applies the `altium-cruncher` PCBLib cleaner profile.
+- The dependency is the installed `altium-cruncher` package, not necessarily the
+  sibling checkout at `C:\eli\wn-hw\altium_cruncher`.
+
+Interpretation: moving Lib Cruncher to a process-level dependency on
+`altium-cruncher` requires more than invoking the existing `clean` command. The
+CLI needs selected-asset, preview/report, and machine-readable inspection
+surfaces that match the current in-process workflows.
+
+### Altium Cruncher CLI Surface Gaps
+
+The current CLI has useful config-driven commands, but it does not yet expose
+all operations needed for Lib Cruncher-style process isolation or GUI preview.
+
+Observed gaps:
+
+- `clean` operates on whole projects/docs/libs and config files, but does not
+  expose selected symbol/footprint extraction plus cleaning as a single
+  daemon-friendly command.
+- `clean` does not currently provide the full JSON report/check mode needed for
+  future "run cleaner on existing library parts" workflows.
+- `libraries --json` lists SchLib/PcbLib contents, but not extraction plans for
+  SchDoc/PcbDoc/PrjPcb/IntLib.
+- `extract` can extract assets, but there is no dry-run/list command that
+  returns the same de-duplicated candidates that extraction would use.
+- `sch-svg` and `pcb-svg` are document-oriented. They do not yet provide a
+  stable selected-symbol or selected-footprint preview surface for viewer tabs.
+- `pcb-svg` does not directly cover single `.PcbLib` footprint preview.
+
+Likely CLI additions:
+
+- read-only list/plan commands for extractable symbols and footprints;
+- selected asset extract/clean/preview commands;
+- JSON report modes for cleaner/check workflows;
+- consistent config resolution for daemon calls;
+- batch manifests for import flows that contain many assets.
+
+### Altium Monkey API Gaps
+
+Several pieces are better introduced in `altium_monkey` first because they are
+CAD-file facts or renderer behavior, not `altium-cruncher` orchestration.
+
+Already filed issues in `altium_monkey_dev`:
+
+- https://github.com/wavenumber-eng/altium_monkey_dev/issues/17 -
+  investigate pad-number overlay support in the PCB SVG renderer.
+- https://github.com/wavenumber-eng/altium_monkey_dev/issues/18 - add
+  read-only asset inspection APIs for extraction preview.
+- https://github.com/wavenumber-eng/altium_monkey_dev/issues/19 - add
+  read-only embedded PCB asset inventory APIs.
+
+The extraction-preview issue should preserve the current extraction semantics:
+
+- SchDoc extraction may have many placed components that share one logical
+  symbol. Preview/list APIs need the same unique-symbol reduction as extract.
+- PcbDoc extraction groups footprints by the existing extraction identity and
+  suffixing behavior, not by a naive component count.
+- PrjPcb and IntLib workflows need list/plan behavior that matches extraction
+  behavior before any files are written.
+
+The embedded-asset issue covers listing embedded 3D models and fonts before a
+full extraction. Megamaid already extracts models at the orchestration layer,
+but the inventory belongs in `altium_monkey` so both Python and C++ users can
+inspect source files before committing to extraction.
+
+### Pad Number Preview Current State
+
+Lib Cruncher adds pad numbers as a bespoke post-processing overlay after SVG
+generation.
+
+Current implementation shape:
+
+- footprint preview calls the `altium_monkey` PCB SVG renderer;
+- Lib Cruncher reaches into renderer context data;
+- Lib Cruncher injects a `<g class="lc-pad-number-overlay">` group by editing
+  the generated SVG string.
+
+Preferred direction:
+
+- add pad-number rendering as a first-class `altium_monkey` PCB SVG renderer
+  option;
+- expose that option through `altium-cruncher` SVG/preview commands;
+- keep Lib Cruncher as a caller of the stable renderer/CLI surface rather than
+  maintaining SVG surgery.
+
+### PR 18 As A Relevant Pressure Test
+
+`altium_cruncher` PR 18 adds an `impedance-doc` command that is config-driven
+and SVG-backed. It is a useful reference for the planned GUI infrastructure even
+if it is not the first pilot.
+
+Relevant properties:
+
+- command creates and consumes a JSONC config;
+- config has a schema id;
+- output is visual documentation derived from PCB SVG rendering;
+- a GUI would need source inventory, preview rendering, parameter editing, and
+  save-config behavior.
+
+This is the same pattern expected for assembly documentation views and future
+highlight/annotation editors.
+
+## Proposed Architecture Direction
+
+### Process Boundary
+
+Future Lib Cruncher and GUI integrations should treat `altium-cruncher` as a
+process-level service or CLI, not as an imported Python implementation detail.
+That leaves room for:
+
+- keeping Lib Cruncher in Python while isolating tool behavior;
+- replacing or accelerating internals with the C++ ports of `altium_monkey` and
+  `altium_cruncher`;
+- using the same headless commands from desktop apps, CI, and local web UIs.
+
+### GUI Mode
+
+Add an `altium-cruncher gui` mode that starts a local daemon and serves a web
+application. The first version should be intentionally small.
+
+Minimum expected shape:
+
+- local-only HTTP server, likely FastAPI initially;
+- static web UI served by the daemon;
+- typed HTTP APIs for inspection, config loading/saving, validation, and
+  rendering;
+- WebSockets only when a use case needs streaming progress or interactive
+  updates;
+- generated OpenAPI and JSON Schema artifacts committed or checked in a
+  reproducible way;
+- frontend types generated from server/API/config schemas;
+- no handwritten duplicate TypeScript interfaces for persisted configs or API
+  payloads.
+
+The daemon is primarily a filesystem and execution bridge. The client should
+not need to know Altium file internals, temporary directory conventions, or
+which `altium-cruncher` internals are used to render a preview.
+
+### Config Files As Project Files
+
+The edited config file is the durable artifact. The GUI is only an editing aid.
+
+Rules to preserve:
+
+- a config created or edited in the GUI can be rerun later from pure CLI;
+- rendered outputs are reproducible from the saved config and source files;
+- GUI-only state must either be absent or explicitly separated from the command
+  config;
+- config schema ids and versions are part of the compatibility contract;
+- JSONC remains useful for humans, while strict JSON Schema remains the
+  machine-checkable contract.
+
+### Contract And Type Generation Pattern
+
+Use the `toolz/data_models` pattern narrowly, not wholesale.
+
+Reference discipline to copy:
+
+- define canonical Python models or schema-backed contracts;
+- emit JSON Schema/OpenAPI where appropriate;
+- generate JavaScript/TypeScript interfaces from those contracts;
+- keep generated files separate from handwritten editor logic;
+- include a freshness check so generated contracts cannot drift from source;
+- include runtime validation helpers where useful.
+
+This should reduce bespoke JS/Python drift while still allowing editor-specific
+operators and UI state to be written in TypeScript or JavaScript.
+
+### Frontend Scope
+
+Do not start with one universal config editor. Build shared infrastructure and
+then one real editor.
+
+Likely shared UI/server capabilities:
+
+- open/load config;
+- validate config and report schema errors;
+- inspect source file capabilities and derived inventory;
+- render preview from a config;
+- save config;
+- manage temporary working directories safely;
+- expose progress/errors in a stable machine-readable format.
+
+Likely editor-specific capabilities:
+
+- controls mapped to one command's config model;
+- domain-specific source inventory views;
+- visual selection and override operations;
+- preview interaction such as enabling/disabling overlays, moving virtual
+  designator projections, or changing colors.
+
+## Candidate First Target Application
+
+The expected first target is an SVG or assembly documentation config editor.
+The exact requirements are intentionally pending.
+
+Known likely needs:
+
+- source `.PcbDoc` or `.PrjPcb` selection;
+- board/layer/view inventory from source files;
+- preview render using the same config consumed by CLI;
+- config editing for assembly views and visual overlays;
+- future interactions for virtual designator projections:
+  - selectively enable or disable items;
+  - reposition projected labels;
+  - adjust colors and style;
+  - persist those edits into the config;
+- save JSONC config for later headless generation.
+
+Potential adjacent pilots:
+
+- cleaner preview/check UI for symbols and footprints;
+- selected symbol/footprint viewer with cleaner controls;
+- impedance/net-class highlight documentation editor based on PR 18.
+
+## Open Design Questions
+
+- What exact command/config should be the first pilot?
+- Should `gui` be a single command with app routes, or should each tool command
+  expose a `--gui` or `preview` subcommand that starts the same daemon?
+- Which contracts are Python-model-first and which are JSON-Schema-first?
+- How much generated frontend code should be committed versus generated during
+  development?
+- What is the first stable API version prefix, for example `/api/acr/v0`?
+- What authentication or local token policy is required for localhost use?
+- Which file operations are allowed from the daemon, and how are project roots
+  constrained?
+- Which preview jobs need WebSockets or cancellation in the first slice?
+- How should temporary extraction folders be named, retained, and cleaned?
+
+## Minimum First Slice Proposal
+
+The first implementation slice should only establish infrastructure needed by
+the selected pilot.
+
+Candidate minimum:
+
+1. `altium-cruncher gui` starts a localhost server and serves a minimal page.
+2. `/health` reports version, process id, and available feature flags.
+3. `/api/acr/v0/config-kinds` lists supported config editors.
+4. One pilot config kind exposes:
+   - schema metadata;
+   - load/validate/save endpoints;
+   - source inspection endpoint;
+   - render-preview endpoint.
+5. OpenAPI and config schema artifacts are generated or checked for freshness.
+6. Frontend TypeScript types are generated from contracts.
+7. Tests cover contract freshness, schema validation, and one preview request at
+   a unit or integration level.
+
+Non-goals for the first slice:
+
+- universal config editing UI;
+- multi-user server;
+- remote deployment;
+- complex job queue unless the pilot requires it;
+- replacing existing CLI commands.
+
+## Documentation And Signoff Expectations
+
+When this moves beyond planning, durable outcomes should be promoted according
+to the repository documentation lifecycle:
+
+- architecture decisions to `docs/adrs/`;
+- public command behavior to `docs/design/cli/`;
+- public API/interface behavior to `docs/design/api/`;
+- schemas and generated contract artifacts to `docs/contracts/`;
+- tests into the appropriate Rack strata and L99 signoff checks.
+
+This plan should remain working material only. Completed decisions and stable
+contracts must not remain trapped here.

--- a/docs/releases/2026-07-29.md
+++ b/docs/releases/2026-07-29.md
@@ -1,0 +1,24 @@
+# Release Notes - 2026-07-29
+
+These notes describe the 2026-07-29 public release for `altium-cruncher` package version `2026.7.29`.
+
+## Release Status
+
+This release consumes the stable `altium-monkey==2026.7.29` compiler release and promotes the downstream design-review output to the compiled physical schematic page model. It replaces the temporary `2026.7.26b1` prerelease pin used during validation.
+
+Please report issues with the exact command, version output, expected behavior, actual behavior, and a public-safe reproduction fixture when possible.
+
+## Highlights
+
+- The package consumes pinned `altium-monkey==2026.7.29`.
+- The package continues to consume pinned `wn-geometer==2026.6.10`.
+- `design`, `design-review`, and `dr` workflows use the `altium_monkey.design.a2` physical-page contract for project schematic review data.
+- Multichannel and repeated-sheet projects emit one schematic SVG/IR per compiled physical page, with `compiled_page_id` coverage in the design-review manifest.
+- Schematic SVG enrichment includes page-local `physical_svg_to_components` metadata so review tools can resolve `physical_page_id|svg_id` to the intended physical component designator.
+- DR schematic SVG output carries resolved component attributes and DNP/fitted state from the compiled design where available.
+- The committed `node_test_array` guard verifies physical page coverage, resolved designators, SVG/IR bundle output, and physical-page component lookup metadata.
+
+## Known Caveats
+
+- Local Altium launch, OutJob execution, and profile cleanup still require Windows with Altium Designer/profile folders present. Discovery/list commands are safe to exercise on Linux/macOS and return empty results when no local Altium state exists.
+- Repeated/channel SVG identity is physical-page scoped. Consumers that previously keyed only by logical SVG element id should use `physical_page_id|svg_id` metadata or the `design.a2` indexes for unambiguous review.

--- a/docs/test-strategy.html
+++ b/docs/test-strategy.html
@@ -1,0 +1,59 @@
+﻿<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Altium Cruncher Test Strategy</title>
+</head>
+<body data-doc="test-strategy" data-doc-status="accepted">
+  <h1>Altium Cruncher Test Strategy</h1>
+
+  <h2>Scope</h2>
+  <p>
+    Altium Cruncher is the command-line and design-review layer over
+    altium-monkey. The test suite validates CLI routing, generated artifacts,
+    public workflows, release metadata, and integration contracts that connect
+    design JSON, schematic SVG, schematic IR, PCB SVG, and review manifests.
+  </p>
+
+  <h2>Rack And Release Gates</h2>
+  <p>
+    Rack is the suite manifest and execution model. The root manifest is
+    <a href="../tests/rack.toml">tests/rack.toml</a>. Lower strata cover focused
+    command behavior and public workflows; <code>L99_signoff</code> is the
+    release metadata, governance, and packaging gate.
+  </p>
+  <p>
+    A release candidate must pass the public workflow lane, the full L99 signoff
+    lane, package build checks, and an installed-console smoke test. Large
+    Altium fixture coverage depends on <code>WN_TEST_CORPUS</code> and should be
+    recorded when it is used for release validation.
+  </p>
+
+  <h2>External Fixtures And Oracles</h2>
+  <p>
+    Real Altium projects and large generated artifacts live outside the Git
+    repository under <code>WN_TEST_CORPUS</code>. Tests that use those projects
+    should degrade cleanly when the corpus is unavailable and should make the
+    dependency explicit in the test name or skip reason.
+  </p>
+
+  <h2>Design Review Contracts</h2>
+  <p>
+    The design-review bundle is the primary end-to-end integration surface. It
+    must preserve links between the high-level design JSON, schematic SVG group
+    identifiers, physical compiled pages, schematic IR, PCB SVG primitives, and
+    manifest entries. Repeated-sheet and channel projects must prefer physical
+    page identifiers over ambiguous logical SVG ids.
+  </p>
+
+  <h2>CLI Governance</h2>
+  <p>
+    Public and experimental commands are listed in
+    <a href="contracts/command_manifest.a0.json">docs/contracts/command_manifest.a0.json</a>.
+    Each command entry points to its CLI design document under
+    <code>docs/design/cli/</code>. Changes to command behavior should update the
+    relevant command design document and any public workflow tests that depend
+    on the behavior.
+  </p>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "altium-cruncher"
-version = "2026.7.9"
+version = "2026.7.29"
 description = "Cross-platform Altium CLI utilities built on public altium-monkey"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -9,7 +9,7 @@ authors = [
     { name = "Wavenumber LLC" },
 ]
 dependencies = [
-    "altium-monkey>=2026.7.9",
+    "altium-monkey==2026.7.29",
     "colorama>=0.4.6",
     "easyeda-monkey>=2026.5.26",
     "json-with-comments>=1.2.10",

--- a/src/py/altium_cruncher/_version.py
+++ b/src/py/altium_cruncher/_version.py
@@ -8,7 +8,7 @@ from datetime import date
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 
-__version__ = "2026.7.9"
+__version__ = "2026.7.29"
 
 _DISTRIBUTION_NAME = "altium-cruncher"
 _CONTROLLED_DEPENDENCIES = (

--- a/src/py/altium_cruncher/altium_cruncher_cmd_design.py
+++ b/src/py/altium_cruncher/altium_cruncher_cmd_design.py
@@ -74,9 +74,10 @@ def register_parser(
         help="generate Altium design review artifacts",
         description=(
             "Generate an Altium design review bundle from SchDoc or PrjPcb "
-            "files. The bundle includes AltiumDesign netlist JSON, serialized SchDoc/"
-            "PcbDoc JSON, schematic SVGs, PCB layer SVGs, structured notes "
-            "JSON, a manifest, and an agent-facing README."
+            "files. The bundle includes AltiumDesign netlist JSON, physical-page "
+            "schematic SVG/IR for project inputs, serialized SchDoc/PcbDoc JSON, "
+            "PCB layer SVGs, structured notes JSON, a manifest, and an agent-facing "
+            "README."
         ),
         epilog=(
             "Examples:\n"

--- a/src/py/altium_cruncher/altium_cruncher_cmd_sch_svg.py
+++ b/src/py/altium_cruncher/altium_cruncher_cmd_sch_svg.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import re
 from pathlib import Path
 
 from altium_cruncher.altium_cruncher_common import (
@@ -19,72 +20,89 @@ def cmd_sch_svg(args) -> int:
     """
     Handle sch-svg subcommand - generate SVG from SchDoc/PrjPcb/SchLib files.
     """
-    from altium_monkey.altium_prjpcb import AltiumPrjPcb
-    from altium_monkey.altium_schdoc import AltiumSchDoc
-    from altium_monkey.altium_schlib import AltiumSchLib
-
-    input_file: Path | None = None
-    if args.file:
-        input_file = Path(args.file).resolve()
-        if not input_file.exists():
-            log.error(f"File not found: {input_file}")
-            return 1
-    else:
-        input_file = find_prjpcb_in_cwd()
-        if not input_file:
-            log.error("No file specified and no .PrjPcb found in current directory")
-            log.info(
-                "Usage: altium-cruncher sch-svg [file.SchDoc | project.PrjPcb | library.SchLib]"
-            )
-            return 1
-        log.info(f"Auto-detected project: {input_file.name}")
-
+    input_file = _resolve_sch_svg_input(args.file)
+    if input_file is None:
+        return 1
     output_dir = _resolve_output_dir(args.output, "sch-svg")
     suffix = input_file.suffix.lower()
 
-    schdoc_files: list[Path] = []
-    project_parameters: dict[str, str] = {}
-
     if suffix == ".schdoc":
-        schdoc_files = [input_file]
-    elif suffix == ".prjpcb":
-        project = AltiumPrjPcb(input_file)
-        schdoc_files = project.get_schdoc_paths()
-        project_parameters = dict(project.parameters)
-        current_variant = project.get_current_variant()
-        if current_variant:
-            project_parameters["VariantName"] = current_variant
-        if not schdoc_files:
-            log.error(f"No SchDoc files found in project: {input_file}")
-            return 1
-        log.info(f"Found {len(schdoc_files)} SchDoc file(s) in project")
-    elif suffix == ".schlib":
-        try:
-            schlib = AltiumSchLib(input_file)
-            log.info(f"Processing SchLib: {input_file.name}")
-            log.info(f"  Symbols: {len(schlib.symbols)}")
+        return _write_logical_schdoc_svgs([input_file], output_dir)
+    if suffix == ".prjpcb":
+        return _write_project_or_logical_svgs(input_file, output_dir)
+    if suffix == ".schlib":
+        return _write_schlib_svgs(input_file, output_dir)
+    log.error(f"Unsupported file type: {suffix}")
+    log.info("Supported schematic SVG types: .SchDoc, .PrjPcb, .SchLib")
+    return 1
 
-            svg_dict = schlib.to_svg(output_dir=output_dir)
 
-            total_svgs = 0
-            for symbol_name, parts in svg_dict.items():
-                for part_id in parts:
-                    total_svgs += 1
-                    if len(parts) > 1:
-                        log.info(f"  -> {symbol_name}_part{part_id}.svg")
-                    else:
-                        log.info(f"  -> {symbol_name}.svg")
+def _resolve_sch_svg_input(raw_file: str | None) -> Path | None:
+    if raw_file:
+        input_file = Path(raw_file).resolve()
+        if input_file.exists():
+            return input_file
+        log.error(f"File not found: {input_file}")
+        return None
+    input_file = find_prjpcb_in_cwd()
+    if input_file:
+        log.info(f"Auto-detected project: {input_file.name}")
+        return input_file
+    log.error("No file specified and no .PrjPcb found in current directory")
+    log.info(
+        "Usage: altium-cruncher sch-svg [file.SchDoc | project.PrjPcb | library.SchLib]"
+    )
+    return None
 
-            log.info(f"Successfully generated {total_svgs} SVG file(s)")
-            return 0
-        except Exception as exc:
-            log.error(f"Error processing SchLib: {exc}")
-            return 1
-    else:
-        log.error(f"Unsupported file type: {suffix}")
-        log.info("Supported schematic SVG types: .SchDoc, .PrjPcb, .SchLib")
+
+def _write_project_or_logical_svgs(input_file: Path, output_dir: Path) -> int:
+    from altium_monkey.altium_design import AltiumDesign
+    from altium_monkey.altium_prjpcb import AltiumPrjPcb
+
+    design = AltiumDesign.from_prjpcb(input_file)
+    project = design.project or AltiumPrjPcb(input_file)
+    schdoc_files = project.get_schdoc_paths()
+    project_parameters = _project_parameters(project)
+    if not schdoc_files:
+        log.error(f"No SchDoc files found in project: {input_file}")
         return 1
+    log.info(f"Found {len(schdoc_files)} SchDoc file(s) in project")
 
+    success_count = _write_project_schematic_svgs(
+        design,
+        output_dir,
+        project_parameters=project_parameters,
+    )
+    if success_count > 0:
+        log.info(f"Successfully generated {success_count} SVG file(s)")
+        return 0
+    log.warning(
+        "No compiled schematic pages were available; falling back to logical SchDoc SVGs"
+    )
+    return _write_logical_schdoc_svgs(
+        schdoc_files,
+        output_dir,
+        project_parameters=project_parameters,
+    )
+
+
+def _project_parameters(project: object) -> dict[str, str]:
+    parameters = dict(getattr(project, "parameters", {}))
+    current_variant = project.get_current_variant()
+    if current_variant:
+        parameters["VariantName"] = current_variant
+    return parameters
+
+
+def _write_logical_schdoc_svgs(
+    schdoc_files: list[Path],
+    output_dir: Path,
+    *,
+    project_parameters: dict[str, str] | None = None,
+) -> int:
+    from altium_monkey.altium_schdoc import AltiumSchDoc
+
+    parameters = project_parameters or {}
     success_count = 0
     for schdoc_path in schdoc_files:
         output_file = output_dir / f"{schdoc_path.stem}.svg"
@@ -92,7 +110,7 @@ def cmd_sch_svg(args) -> int:
         try:
             schdoc = AltiumSchDoc(schdoc_path)
             svg_content = schdoc.to_svg(
-                project_parameters=project_parameters, wrap_components=True
+                project_parameters=parameters, wrap_components=True
             )
             log_current_font_resolution_diagnostics()
             output_file.write_text(svg_content, encoding="utf-8")
@@ -107,6 +125,119 @@ def cmd_sch_svg(args) -> int:
 
     log.warning(f"Generated {success_count}/{len(schdoc_files)} SVG file(s)")
     return 1
+
+
+def _write_schlib_svgs(input_file: Path, output_dir: Path) -> int:
+    from altium_monkey.altium_schlib import AltiumSchLib
+
+    try:
+        schlib = AltiumSchLib(input_file)
+        log.info(f"Processing SchLib: {input_file.name}")
+        log.info(f"  Symbols: {len(schlib.symbols)}")
+        svg_dict = schlib.to_svg(output_dir=output_dir)
+        total_svgs = _log_schlib_svg_outputs(svg_dict)
+        log.info(f"Successfully generated {total_svgs} SVG file(s)")
+        return 0
+    except Exception as exc:
+        log.error(f"Error processing SchLib: {exc}")
+        return 1
+
+
+def _log_schlib_svg_outputs(svg_dict: dict[str, object]) -> int:
+    total_svgs = 0
+    for symbol_name, parts in svg_dict.items():
+        for part_id in parts:
+            total_svgs += 1
+            suffix = f"_part{part_id}" if len(parts) > 1 else ""
+            log.info(f"  -> {symbol_name}{suffix}.svg")
+    return total_svgs
+
+
+def _write_project_schematic_svgs(
+    design: object,
+    output_dir: Path,
+    *,
+    project_parameters: dict[str, str],
+) -> int:
+    """Write compiled/resolved schematic page SVGs for a project input."""
+    to_physical_svg = getattr(design, "to_physical_svg", None)
+    if not callable(to_physical_svg):
+        log.warning("Compiled schematic SVG API is unavailable")
+        return 0
+
+    payload = design.to_json(include_indexes=True)
+    raw_pages = payload.get("physical_pages", [])
+    pages = [page for page in raw_pages if isinstance(page, dict)]
+    if not pages:
+        return 0
+
+    log.info(f"Found {len(pages)} compiled schematic page(s) in project")
+    used_names: set[str] = set()
+    success_count = 0
+    for index, page in enumerate(pages, start=1):
+        page_id = str(page.get("id") or "").strip()
+        if not page_id:
+            continue
+        output_file = output_dir / _compiled_page_svg_filename(
+            page,
+            index=index,
+            used_names=used_names,
+        )
+        log.info(f"Processing compiled page: {page_id}")
+        try:
+            svg_content = to_physical_svg(
+                page_id,
+                project_parameters=project_parameters,
+                wrap_components=True,
+            )
+            log_current_font_resolution_diagnostics()
+            output_file.write_text(svg_content, encoding="utf-8")
+            log.info(f"  -> {output_file.name}")
+            success_count += 1
+        except Exception as exc:
+            log.error(f"Error processing compiled page {page_id}: {exc}")
+    return success_count
+
+
+def _compiled_page_svg_filename(
+    page: dict[str, object],
+    *,
+    index: int,
+    used_names: set[str],
+) -> str:
+    source_sheet = Path(str(page.get("source_sheet") or "sheet")).stem
+    label = _compiled_page_label(page)
+    base = _safe_svg_stem(f"{index:03d}_{source_sheet}_{label}")
+    return _unique_svg_filename(base, used_names)
+
+
+def _compiled_page_label(page: dict[str, object]) -> str:
+    for key in (
+        "room_name",
+        "channel_prefix",
+        "channel_alpha",
+        "physical_instance_path",
+        "id",
+    ):
+        label = str(page.get(key) or "").strip()
+        if label:
+            return label
+    return "sheet"
+
+
+def _unique_svg_filename(base: str, used_names: set[str]) -> str:
+    name = f"{base}.svg"
+    suffix = 2
+    while name.lower() in used_names:
+        name = f"{base}_{suffix}.svg"
+        suffix += 1
+    used_names.add(name.lower())
+    return name
+
+
+def _safe_svg_stem(value: str) -> str:
+    stem = re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("._")
+    return stem or "sheet"
 
 
 def register_parser(subparsers):

--- a/src/py/altium_cruncher/altium_cruncher_design_review.py
+++ b/src/py/altium_cruncher/altium_cruncher_design_review.py
@@ -46,13 +46,30 @@ def write_design_review_bundle(
     schdoc_paths = _schdoc_paths(input_file, design)
     pcbdoc_paths = _pcbdoc_paths(input_file, design)
     source_base = input_file.resolve().parent
-    sch_svgs = _write_schematic_svgs(
-        schdoc_paths,
-        output_dir,
-        design,
-        design_payload=design_payload,
-        source_base=source_base,
-    )
+    if input_file.suffix.lower() == ".prjpcb":
+        sch_svgs, sch_irs = _write_project_schematic_artifacts(
+            output_dir,
+            design,
+            design_payload=design_payload,
+            source_base=source_base,
+        )
+        if not sch_svgs and schdoc_paths:
+            sch_svgs = _write_schematic_svgs(
+                schdoc_paths,
+                output_dir,
+                design,
+                design_payload=design_payload,
+                source_base=source_base,
+            )
+    else:
+        sch_svgs = _write_schematic_svgs(
+            schdoc_paths,
+            output_dir,
+            design,
+            design_payload=design_payload,
+            source_base=source_base,
+        )
+        sch_irs = []
     doc_jsons = _write_document_jsons(
         [*schdoc_paths, *pcbdoc_paths],
         output_dir,
@@ -70,6 +87,7 @@ def write_design_review_bundle(
         doc_jsons=doc_jsons,
         notes_path=notes_path,
         sch_svgs=sch_svgs,
+        sch_irs=sch_irs,
         pcb_artifacts=pcb_artifacts,
         readme_path=readme_path,
     )
@@ -159,6 +177,124 @@ def _write_schematic_svgs(
     return artifacts
 
 
+def _write_project_schematic_artifacts(
+    output_dir: Path,
+    design: object,
+    *,
+    design_payload: dict[str, object],
+    source_base: Path,
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    """Write resolved compiled schematic SVG and IR artifacts for a project."""
+    to_physical_ir = getattr(design, "to_physical_ir", None)
+    if not callable(to_physical_ir):
+        log.warning("Compiled schematic rendering API is unavailable")
+        return [], []
+
+    raw_pages = design_payload.get("physical_pages", [])
+    pages = [page for page in raw_pages if isinstance(page, dict)]
+    if not pages:
+        return [], []
+
+    svg_dir = output_dir / "sch"
+    ir_dir = output_dir / "sch-ir"
+    svg_dir.mkdir(parents=True, exist_ok=True)
+    ir_dir.mkdir(parents=True, exist_ok=True)
+    project_parameters = _project_parameters(design)
+    svg_artifacts: list[dict[str, object]] = []
+    ir_artifacts: list[dict[str, object]] = []
+    render_options = _physical_schematic_render_options()
+    for index, page in enumerate(pages, start=1):
+        page_id = str(page.get("id") or "").strip()
+        if not page_id:
+            continue
+        source_sheet = str(page.get("source_sheet") or "sheet")
+        stem = _safe_artifact_stem(f"{index:03d}_{Path(source_sheet).stem}_{page_id}")
+
+        svg_path = svg_dir / f"{stem}.svg"
+        ir_document = to_physical_ir(
+            page_id,
+            project_parameters=project_parameters,
+            profile="onscreen",
+            render_options=render_options,
+        )
+        ir_path = ir_dir / f"{stem}.gotir.json"
+        ir_path.write_text(
+            json.dumps(ir_document.to_dict(), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        log.info("Schematic IR: %s", _relpath(ir_path, output_dir))
+        ir_artifacts.append(
+            {
+                "file": _relpath(ir_path, output_dir),
+                "compiled_page_id": page_id,
+                "source": _compiled_page_source(page, source_base),
+                "source_sheet": source_sheet,
+                "page_number": index,
+                "page_count": len(pages),
+            }
+        )
+
+        svg = _render_physical_ir_svg(ir_document, render_options=render_options)
+        svg = _enrich_project_schematic_svg(
+            svg,
+            design_payload=design_payload,
+            schematic_page=page,
+            source_base=source_base,
+        )
+        svg_path.write_text(svg, encoding="utf-8")
+        log.info("Schematic SVG: %s", _relpath(svg_path, output_dir))
+        svg_artifacts.append(
+            {
+                "file": _relpath(svg_path, output_dir),
+                "compiled_page_id": page_id,
+                "source": _compiled_page_source(page, source_base),
+                "source_sheet": source_sheet,
+                "page_number": index,
+                "page_count": len(pages),
+            }
+        )
+
+    return svg_artifacts, ir_artifacts
+
+
+def _physical_schematic_render_options() -> object:
+    from altium_monkey.altium_sch_svg_renderer import SchSvgRenderOptions
+
+    return SchSvgRenderOptions()
+
+
+def _render_physical_ir_svg(
+    ir_document: object,
+    *,
+    render_options: object,
+) -> str:
+    from altium_monkey.altium_sch_geometry_renderer import (
+        SchGeometrySvgRenderOptions,
+        SchGeometrySvgRenderer,
+    )
+
+    return SchGeometrySvgRenderer(
+        SchGeometrySvgRenderOptions(
+            include_workspace_background=True,
+            text_mode=(
+                "native_svg_export"
+                if getattr(render_options, "truncate_font_size_for_baseline", False)
+                else "onscreen"
+            ),
+            compile_mask_render_mode=getattr(
+                render_options,
+                "compile_mask_render_mode",
+                None,
+            ),
+            text_as_polygons=bool(getattr(render_options, "text_as_polygons", False)),
+            polygon_text_tolerance=float(
+                getattr(render_options, "polygon_text_tolerance", 0.5)
+            ),
+            include_view_box=bool(getattr(render_options, "include_view_box", True)),
+        )
+    ).render(ir_document)
+
+
 def _enrich_schematic_svg(
     svg: str,
     *,
@@ -190,6 +326,55 @@ def _enrich_schematic_svg(
         svg,
         design_payload=design_payload,
         schdoc_path=schdoc_path,
+    )
+
+
+def _enrich_project_schematic_svg(
+    svg: str,
+    *,
+    design_payload: dict[str, object],
+    schematic_page: dict[str, object],
+    source_base: Path,
+) -> str:
+    """Embed design-review metadata for one compiled schematic page."""
+    rel_source = _compiled_page_source(schematic_page, source_base)
+    page_id = str(schematic_page.get("id") or "")
+    payload = {
+        "schema": SCHEMATIC_SVG_ENRICHMENT_SCHEMA,
+        "source": {
+            "altium_schdoc_file": rel_source,
+            "compiled_page_id": page_id,
+        },
+        "view": {
+            "kind": "compiled_schematic_page",
+            "profile": "design_review",
+            "sheet_name": Path(str(schematic_page.get("source_sheet") or "")).stem,
+            "sheet_file": str(schematic_page.get("source_sheet") or ""),
+            "compiled_page": schematic_page,
+        },
+        "view_indexes": _compiled_schematic_svg_view_indexes(
+            design_payload,
+            schematic_page=schematic_page,
+        ),
+        "design": design_payload,
+    }
+    root_attrs = {
+        "data-enrichment-schema": SCHEMATIC_SVG_ENRICHMENT_SCHEMA,
+        "data-view-kind": "compiled_schematic_page",
+        "data-profile": "design_review",
+        "data-source": rel_source,
+        "data-sheet-name": Path(str(schematic_page.get("source_sheet") or "")).stem,
+        "data-compiled-page-id": page_id,
+        "data-review-theme": SCHEMATIC_REVIEW_THEME,
+    }
+    svg = _inject_svg_root_attrs_and_metadata(
+        svg,
+        root_attrs=root_attrs,
+        metadata_element=_schematic_svg_enrichment_metadata_element(payload),
+    )
+    return _annotate_compiled_schematic_component_groups(
+        svg,
+        schematic_page=schematic_page,
     )
 
 
@@ -285,6 +470,46 @@ def _filtered_component_to_nets(
     }
 
 
+def _compiled_schematic_svg_view_indexes(
+    design_payload: dict[str, object],
+    *,
+    schematic_page: dict[str, object],
+) -> dict[str, object]:
+    raw_components = schematic_page.get("components", [])
+    components = [
+        component
+        for component in raw_components
+        if isinstance(component, dict)
+    ]
+    svg_to_components: dict[str, list[str]] = {}
+    component_to_svg: dict[str, str] = {}
+    for component in components:
+        svg_id = str(component.get("svg_id") or "").strip()
+        designator = str(component.get("designator") or "").strip()
+        if not svg_id or not designator:
+            continue
+        svg_to_components.setdefault(svg_id, []).append(designator)
+        component_to_svg[designator] = svg_id
+    page_id = str(schematic_page.get("id") or "")
+    physical_svg_to_components = {
+        f"{page_id}|{svg_id}": sorted(values)
+        for svg_id, values in sorted(svg_to_components.items())
+    }
+    return {
+        "compiled_page_id": page_id,
+        "svg_to_components": {
+            svg_id: sorted(values)
+            for svg_id, values in sorted(svg_to_components.items())
+        },
+        "physical_svg_to_components": physical_svg_to_components,
+        "component_to_svg": dict(sorted(component_to_svg.items())),
+        "component_to_nets": _filtered_component_to_nets(
+            design_payload,
+            component_to_svg,
+        ),
+    }
+
+
 def _inject_svg_root_attrs_and_metadata(
     svg: str,
     *,
@@ -332,6 +557,25 @@ def _annotate_schematic_component_groups(
     return svg
 
 
+def _annotate_compiled_schematic_component_groups(
+    svg: str,
+    *,
+    schematic_page: dict[str, object],
+) -> str:
+    page_id = str(schematic_page.get("id") or "")
+    for component in schematic_page.get("components", []):
+        if not isinstance(component, dict):
+            continue
+        svg_id = str(component.get("svg_id") or "").strip()
+        if not svg_id:
+            continue
+        attrs = _schematic_component_group_attrs(component, svg_id)
+        attrs["data-compiled-page-id"] = page_id
+        attrs["data-compiled-svg-key"] = f"{page_id}|{svg_id}"
+        svg = _annotate_svg_group_by_id(svg, svg_id, attrs)
+    return svg
+
+
 def _schematic_component_group_attrs(
     component: dict[str, object],
     svg_id: str,
@@ -342,10 +586,34 @@ def _schematic_component_group_attrs(
         "data-element-key": svg_id,
         "data-component-uid": svg_id,
     }
+    attrs.update(_component_identity_attrs(component))
+    attrs.update(_component_variant_attrs(component))
+    attrs.update(_component_descriptive_attrs(component))
+    attrs.update(_component_classification_attrs(component))
+    return attrs
+
+
+def _component_identity_attrs(component: dict[str, object]) -> dict[str, object]:
     designator = str(component.get("designator") or "").strip()
-    if designator:
-        attrs["data-component"] = designator
-        attrs["data-designator"] = designator
+    if not designator:
+        return {}
+    return {
+        "data-component": designator,
+        "data-designator": designator,
+    }
+
+
+def _component_variant_attrs(component: dict[str, object]) -> dict[str, object]:
+    attrs: dict[str, object] = {}
+    if "dnp" in component:
+        attrs["data-dnp"] = "true" if bool(component.get("dnp")) else "false"
+    if "fitted" in component:
+        attrs["data-fitted"] = "true" if bool(component.get("fitted")) else "false"
+    return attrs
+
+
+def _component_descriptive_attrs(component: dict[str, object]) -> dict[str, object]:
+    attrs: dict[str, object] = {}
     for source_key, attr_key in (
         ("library_ref", "data-symbol-library-ref"),
         ("footprint", "data-footprint"),
@@ -354,12 +622,19 @@ def _schematic_component_group_attrs(
         value = str(component.get(source_key) or "").strip()
         if value:
             attrs[attr_key] = value
-    classification = component.get("classification")
-    if isinstance(classification, dict):
-        component_type = str(classification.get("type") or "").strip()
-        if component_type:
-            attrs["data-component-type"] = component_type
     return attrs
+
+
+def _component_classification_attrs(
+    component: dict[str, object],
+) -> dict[str, object]:
+    classification = component.get("classification")
+    if not isinstance(classification, dict):
+        return {}
+    component_type = str(classification.get("type") or "").strip()
+    if not component_type:
+        return {}
+    return {"data-component-type": component_type}
 
 
 def _annotate_svg_group_by_id(
@@ -631,6 +906,7 @@ def _manifest_payload(
     doc_jsons: list[dict[str, object]],
     notes_path: Path,
     sch_svgs: list[dict[str, object]],
+    sch_irs: list[dict[str, object]],
     pcb_artifacts: list[dict[str, object]],
     readme_path: Path,
 ) -> dict[str, object]:
@@ -641,6 +917,7 @@ def _manifest_payload(
         "document_jsons": doc_jsons,
         "notes_json": _relpath(notes_path, output_dir),
         "schematic_svgs": sch_svgs,
+        "schematic_irs": sch_irs,
         "pcb_svgs": pcb_artifacts,
         "readme": _relpath(readme_path, output_dir),
     }
@@ -652,6 +929,7 @@ def _readme_text(
     manifest: dict[str, object],
 ) -> str:
     schematic_count = len(manifest.get("schematic_svgs", []))
+    schematic_ir_count = len(manifest.get("schematic_irs", []))
     pcb_count = sum(
         len(item.get("layer_outputs", []))
         for item in manifest.get("pcb_svgs", [])
@@ -670,8 +948,10 @@ visual schematic and PCB context.
 1. Read `design_review_manifest.json`; all paths in it are relative to this
    folder.
 2. Read `{manifest['design_json']}` for the project-level design model.
-3. Open `sch/*.svg` and `pcb/layers/*.svg` for visual context. The SVGs carry
-   in-band metadata that links drawn objects back to the JSON model.
+3. Open `sch/*.svg` for schematic context. For project inputs these are
+   compiled, resolved schematic pages; for single SchDoc inputs these are
+   logical sheet renders. Open `pcb/layers/*.svg` for PCB context. The SVGs
+   carry in-band metadata that links drawn objects back to the JSON model.
 4. Use `json/schdoc/` and `json/pcbdoc/` only when you need raw Altium document
    details that are not summarized in the design JSON or SVG metadata.
 
@@ -679,7 +959,10 @@ visual schematic and PCB context.
 
 - `{manifest['design_json']}`: Altium Monkey design/netlist JSON. This is the
   primary semantic model for components, nets, hierarchy, variants, PnP, and
-  lookup indexes. For deeper model/API context, see the public
+  lookup indexes. For project inputs this is the compiled physical design view:
+  repeated sheets and channels use resolved physical designators, physical page
+  records, and page-local net/component projections. For deeper model/API
+  context, see the public
   [altium_monkey](https://github.com/wavenumber-eng/altium_monkey) project.
 - `design_review_manifest.json`: artifact index for this bundle.
 - `{manifest['notes_json']}`: JSONC dedicated notes, schematic-owned text
@@ -693,9 +976,13 @@ visual schematic and PCB context.
   `altium_monkey.schdoc.interop.a0` and `altium_monkey.schlib.interop.a0`
   interop formats; PcbDoc payloads use the
   `altium_monkey.pcbdoc.structural.a0` document format.
-- `sch/`: schematic SVGs. Each SVG root has
+- `sch/`: schematic SVGs. For project inputs these are compiled schematic
+  pages with resolved channel/repeated-sheet designators. Each SVG root has
   `data-enrichment-schema="altium_monkey.schematic.svg.enrichment.a0"` and a
   `<metadata id="schematic-enrichment-a0">` JSON payload.
+- `sch-ir/`: schematic IR JSON for project inputs. These use
+  `AltiumDesign.to_physical_ir()` so repeated/channel component designators are
+  resolved before IR emission.
 - `pcb/layers/`: PCB copper-layer SVGs with board outline, cutouts, drills, and
   slots. These use the `altium_monkey.pcb.svg.enrichment.a0` SVG contract.
 
@@ -705,13 +992,24 @@ The design JSON is produced by `altium-monkey` and is the best starting point
 for reasoning about the circuit. Important top-level areas:
 
 - `components`: component rows with designator, value, footprint, library ref,
-  hierarchy, classification, parameters, and `svg_id` where available. This is
-  effectively the BOM-like part of the netlist; use it for designator, value,
-  footprint, library, classification, and parameter review without needing a
-  separate BOM export.
-- `nets`: net rows with endpoint/component relationships.
-- `indexes.svg_to_component`: maps schematic SVG group ids to component
-  designators.
+  hierarchy, classification, parameters, and `svg_id` where available. For
+  project inputs these designators are physical/resolved when the compiled
+  model can resolve repeated sheets or channels. This is effectively the
+  BOM-like part of the netlist; use it for designator, value, footprint,
+  library, classification, and parameter review without needing a separate BOM
+  export.
+- `nets`: net rows with endpoint/component relationships. When available,
+  `aliases` and `name_sources` describe additional labels, ports, power names,
+  and other discovered names that did not win Altium's net-name selection.
+- `physical_pages`: compiled schematic-page records. Each page lists the
+  physical components and nets visible on that page, with source SchDoc lineage.
+- `indexes.svg_to_component`: legacy scalar mapping from schematic SVG group ids
+  to component designators. It is populated only when a logical SVG id maps
+  unambiguously to one physical component.
+- `indexes.svg_to_components`: maps a logical schematic SVG group id to every
+  physical designator represented by that source object.
+- `indexes.physical_svg_to_components`: maps `physical_page_id|svg_id` to the
+  component designator(s) for repeated/channel-safe graphical lookup.
 - `indexes.component_to_nets`: maps component designators to connected nets.
 - `indexes.net_to_components`: maps a net name back to the components on it.
 
@@ -734,18 +1032,24 @@ a derived power-tree view.
 ## Schematic SVG Links
 
 Schematic SVG component groups are annotated when a component `svg_id` is known.
-Look for attributes such as `data-component`, `data-designator`,
-`data-element-key`, `data-symbol-library-ref`, `data-footprint`, and
-`data-value`. To resolve a drawn component to nets:
+For project inputs, the `sch/*.svg` files are compiled physical pages and each
+root carries `data-compiled-page-id`. Component groups also carry
+`data-compiled-svg-key="{{physical_page_id}}|{{svg_id}}"` so repeated/channel
+instances are not confused with their logical source sheet. Look for attributes
+such as `data-component`, `data-designator`, `data-element-key`,
+`data-symbol-library-ref`, `data-footprint`, and `data-value`. To resolve a
+drawn component to nets:
 
 1. Read the SVG group's `data-component` or `data-element-key`.
-2. If using `data-element-key`, resolve it through
-   `indexes.svg_to_component` in the design JSON or through the SVG metadata
-   `view_indexes.svg_to_component`.
-3. Resolve the designator through `indexes.component_to_nets`.
+2. For project inputs, prefer the group's `data-compiled-svg-key` and resolve it
+   through `indexes.physical_svg_to_components` in the design JSON or through
+   the SVG metadata `view_indexes.physical_svg_to_components`.
+3. For simple non-repeated designs, `indexes.svg_to_component` remains a
+   convenient scalar shortcut when it is populated.
+4. Resolve the physical designator through `indexes.component_to_nets`.
 
-The embedded `schematic-enrichment-a0` metadata repeats the relevant view
-indexes so a single SVG can be inspected without first loading every other
+The embedded `schematic-enrichment-a0` metadata repeats the relevant page-local
+view indexes so a single SVG can be inspected without first loading every other
 artifact.
 
 ## PCB SVG Links
@@ -764,6 +1068,7 @@ specific primitive or document-level board data.
 ## Counts
 
 - Schematic SVGs: {schematic_count}
+- Schematic IRs: {schematic_ir_count}
 - PCB layer SVGs: {pcb_count}
 
 Generated artifact paths in `design_review_manifest.json` are relative to this
@@ -788,3 +1093,15 @@ def _source_path(path: Path, source_base: Path) -> str:
         return path.resolve().relative_to(source_base.resolve()).as_posix()
     except ValueError:
         return path.name
+
+
+def _compiled_page_source(page: dict[str, object], source_base: Path) -> str:
+    source_path = str(page.get("source_path") or "").strip()
+    if source_path:
+        return _source_path(Path(source_path), source_base)
+    return str(page.get("source_sheet") or "")
+
+
+def _safe_artifact_stem(value: str) -> str:
+    stem = re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("._")
+    return stem or "artifact"

--- a/src/py/altium_cruncher/altium_cruncher_pcb_svg_a0_renderer.py
+++ b/src/py/altium_cruncher/altium_cruncher_pcb_svg_a0_renderer.py
@@ -1573,7 +1573,21 @@ class PcbSvgA0Renderer(CruncherPcbCutoutLayerRenderer):
 
         if not primitives and not self.options.show_empty_layers:
             return []
-        return self._render_layer_group_from_primitives(  # noqa: SLF001
+        import inspect
+
+        render_layer_group = self._render_layer_group_from_primitives  # noqa: SLF001
+        if "overlay_primitives" in inspect.signature(render_layer_group).parameters:
+            return render_layer_group(
+                ctx,
+                layer,
+                color,
+                primitives,
+                [],
+                [],
+                clip_path_id=clip_path_id,
+                mask_id=mask_id,
+            )
+        return render_layer_group(
             ctx,
             layer,
             color,

--- a/tests/L0_public_cli/test_L0_001_cli_entrypoint.py
+++ b/tests/L0_public_cli/test_L0_001_cli_entrypoint.py
@@ -87,6 +87,7 @@ def test_design_help_describes_design_json_contents() -> None:
 
     assert result.returncode == 0, result.stderr
     assert "design review bundle" in result.stdout
+    assert "physical-page schematic SVG/IR" in result.stdout
     assert "serialized SchDoc/PcbDoc JSON" in result.stdout
     assert "structured notes" in result.stdout
     assert "output/design_review" in result.stdout

--- a/tests/L3_public_workflows/test_L3_001_public_cli_workflows.py
+++ b/tests/L3_public_workflows/test_L3_001_public_cli_workflows.py
@@ -28,6 +28,8 @@ HYDROSCOPE_PROJECT = HYDROSCOPE_DIR / "Hydroscope.PrjPcb"
 HYDROSCOPE_SCHDOC = HYDROSCOPE_DIR / "CPU.SchDoc"
 HYDROSCOPE_SCHLIB = HYDROSCOPE_DIR / "Hydroscope.SCHLIB"
 HYDROSCOPE_PCBDOC = HYDROSCOPE_DIR / "TZ-SB-0001-PCB-[A] (HydroScope Mainboard).PcbDoc"
+NODE_TEST_ARRAY_DIR = PACKAGE_ROOT / "tests" / "assets" / "projects" / "node_test_array" / "input"
+NODE_TEST_ARRAY_PROJECT = NODE_TEST_ARRAY_DIR / "11-10077__node-test-array__B4.PrjPcb"
 RT_SUPER_C1_INTLIB = (
     PACKAGE_ROOT
     / "tests"
@@ -118,9 +120,77 @@ def test_schematic_and_design_json_commands_use_public_project(tmp_path: Path) -
     design_payload = json.loads(
         (design_dir / "design" / "Hydroscope_design.json").read_text(encoding="utf-8")
     )
+    assert design_payload["schema"] == "altium_monkey.design.a2"
     assert len(design_payload["components"]) >= 100
     assert len(design_payload["nets"]) >= 100
+    assert isinstance(design_payload["physical_pages"], list)
     assert design_payload["indexes"]["svg_to_component"]
+
+
+def test_design_review_bundle_uses_physical_pages_for_multichannel_project(
+    tmp_path: Path,
+) -> None:
+    """Verify DR emits resolved physical-page SVG/IR artifacts for channel projects."""
+    output_dir = tmp_path / "node-test-array-dr"
+
+    _run_cli("dr", str(NODE_TEST_ARRAY_PROJECT), "-o", str(output_dir))
+
+    manifest = json.loads(
+        (output_dir / "design_review_manifest.json").read_text(encoding="utf-8")
+    )
+    design_payload = json.loads(
+        (output_dir / manifest["design_json"]).read_text(encoding="utf-8")
+    )
+    physical_pages = [
+        page for page in design_payload["physical_pages"] if isinstance(page, dict)
+    ]
+    physical_page_ids = {str(page["id"]) for page in physical_pages}
+    svg_page_ids = {
+        str(entry["compiled_page_id"])
+        for entry in manifest["schematic_svgs"]
+        if isinstance(entry, dict)
+    }
+    ir_page_ids = {
+        str(entry["compiled_page_id"])
+        for entry in manifest["schematic_irs"]
+        if isinstance(entry, dict)
+    }
+
+    assert design_payload["schema"] == "altium_monkey.design.a2"
+    assert len(physical_pages) >= 2
+    assert svg_page_ids == physical_page_ids
+    assert ir_page_ids == physical_page_ids
+
+    page_with_component = next(
+        page
+        for page in physical_pages
+        if any(
+            isinstance(component, dict) and component.get("svg_id")
+            for component in page.get("components", [])
+        )
+    )
+    component = next(
+        component
+        for component in page_with_component["components"]
+        if isinstance(component, dict) and component.get("svg_id")
+    )
+    page_id = str(page_with_component["id"])
+    svg_id = str(component["svg_id"])
+    designator = str(component["designator"])
+    physical_svg_key = f"{page_id}|{svg_id}"
+
+    indexes = design_payload["indexes"]
+    assert designator in indexes["physical_svg_to_components"][physical_svg_key]
+    assert designator in indexes["component_to_nets"]
+
+    svg_entry = next(
+        entry for entry in manifest["schematic_svgs"] if entry["compiled_page_id"] == page_id
+    )
+    svg_text = (output_dir / svg_entry["file"]).read_text(encoding="utf-8")
+    assert 'data-view-kind="compiled_schematic_page"' in svg_text
+    assert f'data-compiled-page-id="{page_id}"' in svg_text
+    assert f'data-compiled-svg-key="{physical_svg_key}"' in svg_text
+    assert f'data-component="{designator}"' in svg_text
 
 
 def test_bom_pnp_config_and_jlc_command_use_public_project(tmp_path: Path) -> None:

--- a/tests/L99_signoff/test_L99_001_release_signoff.py
+++ b/tests/L99_signoff/test_L99_001_release_signoff.py
@@ -23,17 +23,16 @@ def _project_root() -> Path:
 
 
 PACKAGE_ROOT = _project_root()
-EXPECTED_VERSION = "2026.7.9"
-EXPECTED_RELEASE_DATE = date(2026, 7, 9)
-EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-07-09.md"
+EXPECTED_VERSION = "2026.7.29"
+EXPECTED_RELEASE_DATE = date(2026, 7, 29)
+EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-07-29.md"
 CONTROLLED_DEPENDENCY_REQUIREMENTS = {
-    "altium-monkey": ">=2026.7.9",
+    "altium-monkey": "==2026.7.29",
     "wn-geometer": "==2026.6.10",
 }
-MINIMUM_CONTROLLED_DEPENDENCIES = {
-    "altium-monkey": "2026.7.9",
-}
+MINIMUM_CONTROLLED_DEPENDENCIES: dict[str, str] = {}
 EXACT_CONTROLLED_DEPENDENCIES = {
+    "altium-monkey": "2026.7.29",
     "wn-geometer": "2026.6.10",
 }
 
@@ -49,7 +48,7 @@ def test_version_contract_matches_date_based_release() -> None:
     assert (version.major, version.minor, version.patch, version.build) == (
         2026,
         7,
-        9,
+        29,
         None,
     )
     assert version.release_date == EXPECTED_RELEASE_DATE

--- a/tests/L99_signoff/test_L99_002_design_docs.py
+++ b/tests/L99_signoff/test_L99_002_design_docs.py
@@ -20,12 +20,13 @@ def _project_root() -> Path:
 PACKAGE_ROOT = _project_root()
 DESIGN_ROOT = PACKAGE_ROOT / "docs" / "design"
 COMMAND_MANIFEST = PACKAGE_ROOT / "docs" / "contracts" / "command_manifest.a0.json"
+COMMAND_MANIFEST_SCHEMA = "wn_dev_std.command_manifest.a0"
 
 
 def _manifest_commands() -> list[str]:
     """Return registered public command names from the command manifest."""
     payload = json.loads(COMMAND_MANIFEST.read_text(encoding="utf-8"))
-    assert payload["schema"] == "altium_cruncher.command_manifest.a0"
+    assert payload["schema"] == COMMAND_MANIFEST_SCHEMA
     commands = payload["commands"]
     assert isinstance(commands, list)
     return [str(command["name"]) for command in commands]

--- a/tests/L99_signoff/test_L99_005_config_contracts.py
+++ b/tests/L99_signoff/test_L99_005_config_contracts.py
@@ -53,6 +53,7 @@ CONTRACTS_ROOT = PACKAGE_ROOT / "docs" / "contracts"
 DESIGN_ROOT = PACKAGE_ROOT / "docs" / "design"
 CLI_DESIGN_ROOT = DESIGN_ROOT / "cli"
 COMMAND_MANIFEST = CONTRACTS_ROOT / "command_manifest.a0.json"
+COMMAND_MANIFEST_SCHEMA = "wn_dev_std.command_manifest.a0"
 
 
 class _DataAttrParser(HTMLParser):
@@ -74,7 +75,7 @@ class _DataAttrParser(HTMLParser):
 
 def _manifest_commands() -> list[str]:
     payload = json.loads(COMMAND_MANIFEST.read_text(encoding="utf-8"))
-    assert payload["schema"] == "altium_cruncher.command_manifest.a0"
+    assert payload["schema"] == COMMAND_MANIFEST_SCHEMA
     commands = payload["commands"]
     assert isinstance(commands, list)
     return [str(command["name"]) for command in commands]

--- a/tests/test_notes_and_design_review.py
+++ b/tests/test_notes_and_design_review.py
@@ -6,9 +6,11 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import jsonc  # type: ignore[import-untyped]
+import pytest
 
 from altium_monkey.altium_record_types import SchPointMils, SchRectMils
 from altium_monkey.altium_sch_object_factory import (
@@ -19,7 +21,10 @@ from altium_monkey.altium_sch_object_factory import (
 from altium_monkey.altium_schdoc import AltiumSchDoc
 
 from altium_cruncher.altium_cruncher_notes import build_notes_payload
-from altium_cruncher.altium_cruncher_design_review import _enrich_schematic_svg
+from altium_cruncher.altium_cruncher_design_review import (
+    _enrich_schematic_svg,
+    _write_project_schematic_artifacts,
+)
 
 
 _LOW_LEVEL_NOTE_KEYS = {
@@ -120,13 +125,53 @@ def _write_review_pcb_project(project_path: Path) -> Path:
 
 
 def _run_cli(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    python_paths = [str(repo_root / "src" / "py")]
+    monkey_dev_src = Path(
+        os.environ.get("ALTIUM_MONKEY_DEV", r"C:\eli\altium_monkey_dev")
+    ) / "src" / "py"
+    if monkey_dev_src.exists():
+        python_paths.insert(0, str(monkey_dev_src))
+    env["PYTHONPATH"] = (
+        os.pathsep.join(python_paths)
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join(python_paths) + os.pathsep + env["PYTHONPATH"]
+    )
     return subprocess.run(
         [sys.executable, "-m", "altium_cruncher", *args],
         cwd=repo_root,
+        env=env,
         capture_output=True,
         text=True,
         check=False,
     )
+
+
+def _node_test_array_project_path() -> Path:
+    corpus_root = Path(os.environ.get("WN_TEST_CORPUS", r"C:\eli\wn_test_corpus"))
+    project_path = (
+        corpus_root
+        / "altium"
+        / "common"
+        / "real_world_pcbdoc"
+        / "node_test_array"
+        / "input"
+        / "11-10077__node-test-array__B4.PrjPcb"
+    )
+    if not project_path.exists():
+        pytest.skip(f"node_test_array corpus fixture not found: {project_path}")
+    return project_path
+
+
+def _iter_json_strings(value: object) -> Iterator[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from _iter_json_strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_json_strings(child)
 
 
 def test_notes_payload_separates_note_text_frame_and_free_text(tmp_path: Path) -> None:
@@ -222,6 +267,7 @@ def test_design_review_bundle_writes_agent_artifacts(tmp_path: Path) -> None:
     assert len(manifest["schematic_svgs"]) == 1
     assert manifest["schematic_svgs"][0]["source"] == "annotated.SchDoc"
     assert manifest["schematic_svgs"][0]["file"].startswith("sch/")
+    assert manifest["schematic_irs"] == []
     assert manifest["pcb_svgs"] == []
     assert "Document JSON: json/schdoc/annotated.SchDoc.json" in result.stdout
     assert "Schematic SVG: sch/annotated.svg" in result.stdout
@@ -243,6 +289,8 @@ def test_design_review_bundle_writes_agent_artifacts(tmp_path: Path) -> None:
     assert "altium_monkey.schdoc.interop.a0" in readme
     assert "BOM-like part of the netlist" in readme
     assert "Power-Tree Review Hint" in readme
+    assert "compiled, resolved schematic pages" in readme
+    assert "sch-ir/" in readme
     assert "zero-ohm" in readme
     assert "current-sense resistors" in readme
     assert "indexes.component_to_nets" in readme
@@ -316,6 +364,188 @@ def test_design_review_schematic_svg_enrichment_embeds_component_lookup(
     assert '"ABC123": "R1"' in enriched
 
 
+def test_design_review_project_schematic_artifacts_are_compiled_outputs(
+    tmp_path: Path,
+) -> None:
+    """Project schematic review outputs should be compiled pages by default."""
+
+    from altium_monkey.altium_sch_geometry_oracle import (
+        SchGeometryDocument,
+        SchGeometryOp,
+        SchGeometryRecord,
+    )
+
+    class FakeDesign:
+        project = None
+
+        def __init__(self) -> None:
+            self.ir_calls = 0
+
+        def to_physical_ir(self, page_id: str, **kwargs: object) -> SchGeometryDocument:
+            self.ir_calls += 1
+            assert page_id == "PDOC1"
+            assert kwargs["profile"] == "onscreen"
+            return SchGeometryDocument(
+                records=[
+                    SchGeometryRecord(
+                        handle="1",
+                        unique_id="CUID1",
+                        kind="component",
+                        object_id="eComponent",
+                        operations=[
+                            SchGeometryOp.string(
+                                x=10,
+                                y=-10,
+                                text="R1.1",
+                                font={"name": "Arial", "size": 12, "rotation": 0},
+                                brush={"color_hex": "#000000"},
+                            )
+                        ],
+                    )
+                ],
+                document_id=page_id,
+                canvas={"width_px": 100, "height_px": 100},
+                coordinate_space={"units_per_px": 64},
+            )
+
+    design_payload: dict[str, object] = {
+        "physical_pages": [
+            {
+                "id": "PDOC1",
+                "source_sheet": "Sheet1.SchDoc",
+                "source_path": str(tmp_path / "Sheet1.SchDoc"),
+                "components": [
+                    {
+                        "designator": "R1.1",
+                        "svg_id": "CUID1",
+                        "value": "10k",
+                        "library_ref": "RES",
+                    }
+                ],
+            }
+        ],
+        "indexes": {"component_to_nets": {"R1.1": ["VIN"]}},
+    }
+
+    fake_design = FakeDesign()
+    svgs, irs = _write_project_schematic_artifacts(
+        tmp_path / "review",
+        fake_design,
+        design_payload=design_payload,
+        source_base=tmp_path,
+    )
+
+    assert fake_design.ir_calls == 1
+    assert len(svgs) == 1
+    assert len(irs) == 1
+    assert svgs[0]["file"].startswith("sch/")
+    assert irs[0]["file"].startswith("sch-ir/")
+    assert "/physical/" not in svgs[0]["file"]
+    assert "/physical/" not in irs[0]["file"]
+    assert svgs[0]["compiled_page_id"] == "PDOC1"
+    svg = (tmp_path / "review" / svgs[0]["file"]).read_text(encoding="utf-8")
+    assert 'data-view-kind="compiled_schematic_page"' in svg
+    assert 'data-compiled-page-id="PDOC1"' in svg
+    assert 'data-component="R1.1"' in svg
+
+
+def test_design_review_node_test_array_uses_compiled_physical_pages(
+    tmp_path: Path,
+) -> None:
+    """Real-world DR bundles should expose resolved compiled schematic pages."""
+    repo_root = Path(__file__).resolve().parents[1]
+    project_path = _node_test_array_project_path()
+    output_dir = tmp_path / "node_test_array_review"
+
+    result = _run_cli(repo_root, "dr", str(project_path), "-o", str(output_dir))
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    manifest = json.loads(
+        (output_dir / "design_review_manifest.json").read_text(encoding="utf-8")
+    )
+    design_payload = json.loads(
+        (output_dir / manifest["design_json"]).read_text(encoding="utf-8")
+    )
+    physical_pages = [
+        page for page in design_payload["physical_pages"] if isinstance(page, dict)
+    ]
+    physical_page_ids = {str(page["id"]) for page in physical_pages}
+    svg_page_ids = {
+        str(entry["compiled_page_id"]) for entry in manifest["schematic_svgs"]
+    }
+    ir_page_ids = {
+        str(entry["compiled_page_id"]) for entry in manifest["schematic_irs"]
+    }
+
+    assert len(physical_pages) > len({page["source_sheet"] for page in physical_pages})
+    assert len(manifest["schematic_svgs"]) == len(physical_pages)
+    assert len(manifest["schematic_irs"]) == len(physical_pages)
+    assert svg_page_ids == physical_page_ids
+    assert ir_page_ids == physical_page_ids
+
+    page_component_designators = {
+        str(component["designator"])
+        for page in physical_pages
+        for component in page.get("components", [])
+        if isinstance(component, dict) and str(component.get("designator") or "")
+    }
+    top_level_component_designators = {
+        str(component["designator"])
+        for component in design_payload["components"]
+        if isinstance(component, dict) and str(component.get("designator") or "")
+    }
+    assert page_component_designators
+    assert page_component_designators <= top_level_component_designators
+
+    resolved_component = next(
+        component
+        for component in design_payload["components"]
+        if isinstance(component, dict)
+        and component.get("logical_designator")
+        and component.get("logical_designator") != component.get("designator")
+        and component.get("physical_sheet_id") in physical_page_ids
+    )
+    resolved_designator = str(resolved_component["designator"])
+    resolved_page_id = str(resolved_component["physical_sheet_id"])
+    svg_entry = next(
+        entry
+        for entry in manifest["schematic_svgs"]
+        if entry["compiled_page_id"] == resolved_page_id
+    )
+    ir_entry = next(
+        entry
+        for entry in manifest["schematic_irs"]
+        if entry["compiled_page_id"] == resolved_page_id
+    )
+
+    svg_text = (output_dir / svg_entry["file"]).read_text(encoding="utf-8")
+    assert f'data-compiled-page-id="{resolved_page_id}"' in svg_text
+    assert f'data-component="{resolved_designator}"' in svg_text
+    assert resolved_designator in svg_text
+
+    dnp_component = next(
+        component
+        for component in design_payload["components"]
+        if isinstance(component, dict)
+        and component.get("dnp") is True
+        and component.get("physical_sheet_id") in physical_page_ids
+    )
+    dnp_designator = str(dnp_component["designator"])
+    dnp_page_id = str(dnp_component["physical_sheet_id"])
+    dnp_svg_entry = next(
+        entry
+        for entry in manifest["schematic_svgs"]
+        if entry["compiled_page_id"] == dnp_page_id
+    )
+    dnp_svg_text = (output_dir / dnp_svg_entry["file"]).read_text(encoding="utf-8")
+    assert f'data-component="{dnp_designator}"' in dnp_svg_text
+    assert 'data-dnp="true"' in dnp_svg_text
+    assert 'data-fitted="false"' in dnp_svg_text
+
+    ir_payload = json.loads((output_dir / ir_entry["file"]).read_text(encoding="utf-8"))
+    assert resolved_designator in set(_iter_json_strings(ir_payload))
+
+
 def test_design_review_pcb_svgs_are_copper_layer_only(tmp_path: Path) -> None:
     """Verify dr emits cheap copper review layers and no composed assembly views."""
     repo_root = Path(__file__).resolve().parents[1]
@@ -328,6 +558,13 @@ def test_design_review_pcb_svgs_are_copper_layer_only(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr + result.stdout
     manifest = json.loads(
         (output_dir / "design_review_manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["schematic_svgs"]
+    assert "physical_schematic_svgs" not in manifest
+    assert "physical_schematic_irs" not in manifest
+    assert all(
+        entry["file"].startswith("sch/") and "/physical/" not in entry["file"]
+        for entry in manifest["schematic_svgs"]
     )
     assert len(manifest["pcb_svgs"]) == 1
     pcb_entry = manifest["pcb_svgs"][0]

--- a/tests/test_sch_svg_display_modes.py
+++ b/tests/test_sch_svg_display_modes.py
@@ -1,6 +1,9 @@
 import argparse
 
-from altium_cruncher.altium_cruncher_cmd_sch_svg import cmd_sch_svg
+from altium_cruncher.altium_cruncher_cmd_sch_svg import (
+    _write_project_schematic_svgs,
+    cmd_sch_svg,
+)
 from altium_monkey.altium_record_sch__pin import AltiumSchPin
 from altium_monkey.altium_record_sch__rectangle import AltiumSchRectangle
 from altium_monkey.altium_record_types import CoordPoint
@@ -55,3 +58,41 @@ def test_sch_svg_command_filters_component_display_modes(tmp_path) -> None:
     assert "MODE_0" not in svg
     assert "CLI_DM1_RECT" in svg
     assert "MODE_1" in svg
+
+
+def test_sch_svg_project_writer_emits_compiled_page_svgs(tmp_path) -> None:
+    class FakeDesign:
+        def to_json(self, *, include_indexes: bool) -> dict[str, object]:
+            assert include_indexes is True
+            return {
+                "physical_pages": [
+                    {
+                        "id": "PAGE_A",
+                        "source_sheet": "Leaf.SchDoc",
+                        "room_name": "Leaf_A",
+                    },
+                    {
+                        "id": "PAGE_B",
+                        "source_sheet": "Leaf.SchDoc",
+                        "room_name": "Leaf_B",
+                    },
+                ]
+            }
+
+        def to_physical_svg(self, page_id: str, **kwargs: object) -> str:
+            assert kwargs["project_parameters"] == {"VariantName": "Base"}
+            assert kwargs["wrap_components"] is True
+            designator = {"PAGE_A": "R1.1", "PAGE_B": "R1.2"}[page_id]
+            return f'<svg data-doc-id="{page_id}"><text>{designator}</text></svg>'
+
+    count = _write_project_schematic_svgs(
+        FakeDesign(),
+        tmp_path,
+        project_parameters={"VariantName": "Base"},
+    )
+
+    assert count == 2
+    outputs = sorted(path.name for path in tmp_path.glob("*.svg"))
+    assert outputs == ["001_Leaf_Leaf_A.svg", "002_Leaf_Leaf_B.svg"]
+    assert "R1.1" in (tmp_path / outputs[0]).read_text(encoding="utf-8")
+    assert "R1.2" in (tmp_path / outputs[1]).read_text(encoding="utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.12.*"
 
 [[package]]
 name = "altium-cruncher"
-version = "2026.7.9"
+version = "2026.7.29"
 source = { editable = "." }
 dependencies = [
     { name = "altium-monkey" },
@@ -40,7 +40,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "altium-monkey", specifier = ">=2026.7.9" },
+    { name = "altium-monkey", specifier = "==2026.7.29" },
     { name = "build", marker = "extra == 'test'", specifier = ">=1.2.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "easyeda-monkey", specifier = ">=2026.5.26" },
@@ -70,7 +70,7 @@ dev = [
 
 [[package]]
 name = "altium-monkey"
-version = "2026.7.9"
+version = "2026.7.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "freetype-py" },
@@ -80,9 +80,9 @@ dependencies = [
     { name = "uharfbuzz" },
     { name = "wn-geometer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/40/7fdc918d1731928252dd8536642724ea40a72b5d0f0a19fcf891c4e9b326/altium_monkey-2026.7.9.tar.gz", hash = "sha256:2567706c4ea1cf2c76bc47695b21eae67a6ea544c88d2c378daa43e8982c26f2", size = 4135780, upload-time = "2026-07-09T17:40:28.387Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/1e/0b4058e4c2614eb9990b28c3717726f501812b54cefa2046bbdf5d374d96/altium_monkey-2026.7.29.tar.gz", hash = "sha256:e3d6453d8e4548d43fbf0d75237fab9ad95e4a7672c94d9dbe0f3577ec4ffcac", size = 4204268, upload-time = "2026-07-29T14:53:53.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/90/752a795a7a059a799ad1e49913c40b2afa4d0e8a68342b7c088010c238eb/altium_monkey-2026.7.9-py3-none-any.whl", hash = "sha256:6f2782f4d41c268885b52cab631d177a6570ba4089481b576fb1747f8af97989", size = 4226623, upload-time = "2026-07-09T17:40:26.466Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d8/fe462e4f94b75bbe49673bbcace34eb156a453416f3195a6764202af5537/altium_monkey-2026.7.29-py3-none-any.whl", hash = "sha256:d6a1380e894b9edf4937fc650df6dfa0a30a535f9fe5828e4e12b23f5717aa69", size = 4297468, upload-time = "2026-07-29T14:53:50.713Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Linked issue: #33

Release altium-cruncher 2026.7.29.

Validation run locally:
- uv run pytest tests\\L99_signoff -q: 17 passed
- WN_TEST_CORPUS=C:\\eli\\wn_test_corpus uv run pytest tests\\L3_public_workflows -q: 21 passed, 1 skipped
- uvx --from git+https://github.com/wavenumber-eng/wn-dev-std.git wn-dev-std check . --format text: passed
- uv run --extra test python -m build --outdir dist_20260729: built wheel and sdist
- uv run --extra test twine check dist_20260729/*: passed
- Published to PyPI: https://pypi.org/project/altium-cruncher/2026.7.29/

This release pins altium-monkey==2026.7.29 and includes the compiled physical-page design-review/SVG changes.