### PR TITLE
release: publish altium-cruncher 2026.8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 2026.8.11
+
+- Consume pinned `altium-monkey==2026.8.11`, carrying the schematic Unicode record-encoding correction through `design`, Design Review, MegaMaid, `sch-svg`, and other Altium-backed workflows.
+- Preserve leading and trailing whitespace in authoritative `%UTF8%` sidecars while retaining CP1252-safe fallback fields for older Altium readers.
+- Recover valid legacy unmarked UTF-8 with contextual diagnostics and reject malformed byte sequences instead of silently producing control characters or corrupted text.
+- Keep the Design b0 compiled schematic graph, graph-scoped SVG metadata, and Cruncher b0 output contracts unchanged.
+
 ## 2026.8.10
 
 - Consume pinned `altium-monkey==2026.8.10` and require the authoritative Design b0 compiled schematic graph for schematic/project review workflows.

--- a/docs/releases/2026-08-11.md
+++ b/docs/releases/2026-08-11.md
@@ -1,0 +1,42 @@
+# Release Notes - 2026-08-11
+
+These notes describe the 2026-08-11 public release for `altium-cruncher`
+package version `2026.8.11`.
+
+## Release Status
+
+This patch release consumes `altium-monkey==2026.8.11`. It carries corrected
+schematic Unicode record decoding and serialization into every Cruncher
+workflow that reads or rewrites SchDoc, SchLib, or project design data.
+
+Please report issues with the exact command, version output, expected behavior,
+actual behavior, and a public-safe reproduction fixture when possible.
+
+## Highlights
+
+- Unicode schematic fields are written through authoritative `%UTF8%<Field>`
+  sidecars with CP1252-safe ordinary fallback fields.
+- Sidecar synthesis preserves leading and trailing whitespace exactly.
+- Valid legacy unmarked UTF-8 is recovered with record and field context in
+  diagnostics; malformed byte sequences fail closed instead of being silently
+  mapped to control characters.
+- `design`, Design Review/`dr`, MegaMaid, `sch-svg`, and combined SVG workflows
+  all receive the corrected behavior through the public Altium Monkey pin.
+
+## Compatibility
+
+- The Design b0 compiled schematic graph and source-neutral identity namespace
+  are unchanged.
+- Design Review, schematic SVG enrichment/manifest, and MegaMaid b0 schemas are
+  unchanged.
+- Existing CP1252-only schematic records continue to decode and round-trip as
+  before.
+
+## Verification
+
+- The complete public Rack passed 74 tests with one optional native skip and
+  all 12 subtests green.
+- Distribution build, Twine metadata, and isolated installed-console checks
+  are release gates.
+- The dependency lock resolves the published `altium-monkey==2026.8.11` wheel
+  from PyPI rather than a source overlay.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "altium-cruncher"
-version = "2026.8.10"
+version = "2026.8.11"
 description = "Cross-platform Altium CLI utilities built on public altium-monkey"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -9,7 +9,7 @@ authors = [
     { name = "Wavenumber LLC" },
 ]
 dependencies = [
-    "altium-monkey==2026.8.10",
+    "altium-monkey==2026.8.11",
     "colorama>=0.4.6",
     "easyeda-monkey>=2026.5.26",
     "json-with-comments>=1.2.10",
@@ -52,7 +52,7 @@ acr = "altium_cruncher._cli:main"
 ad = "altium_cruncher.altium_cruncher_cmd_launch:main_ad"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.31.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]

--- a/src/py/altium_cruncher/_version.py
+++ b/src/py/altium_cruncher/_version.py
@@ -8,7 +8,7 @@ from datetime import date
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 
-__version__ = "2026.8.10"
+__version__ = "2026.8.11"
 
 _DISTRIBUTION_NAME = "altium-cruncher"
 _CONTROLLED_DEPENDENCIES = (

--- a/tests/L99_signoff/test_L99_001_release_signoff.py
+++ b/tests/L99_signoff/test_L99_001_release_signoff.py
@@ -23,16 +23,16 @@ def _project_root() -> Path:
 
 
 PACKAGE_ROOT = _project_root()
-EXPECTED_VERSION = "2026.8.10"
-EXPECTED_RELEASE_DATE = date(2026, 8, 10)
-EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-08-10.md"
+EXPECTED_VERSION = "2026.8.11"
+EXPECTED_RELEASE_DATE = date(2026, 8, 11)
+EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-08-11.md"
 CONTROLLED_DEPENDENCY_REQUIREMENTS = {
-    "altium-monkey": "==2026.8.10",
+    "altium-monkey": "==2026.8.11",
     "wn-geometer": "==2026.6.10",
 }
 MINIMUM_CONTROLLED_DEPENDENCIES: dict[str, str] = {}
 EXACT_CONTROLLED_DEPENDENCIES = {
-    "altium-monkey": "2026.8.10",
+    "altium-monkey": "2026.8.11",
     "wn-geometer": "2026.6.10",
 }
 
@@ -50,7 +50,7 @@ def test_version_contract_matches_date_based_release() -> None:
     assert (version.major, version.minor, version.patch, version.build) == (
         2026,
         8,
-        10,
+        11,
         None,
     )
     assert version.release_date == EXPECTED_RELEASE_DATE
@@ -139,6 +139,15 @@ def test_developer_working_docs_are_excluded_from_release_artifacts() -> None:
     assert "docs/**" in sdist["include"]
     assert "docs/plans/**" in sdist["exclude"]
     assert "docs/research/**" in sdist["exclude"]
+
+
+def test_release_build_backend_is_metadata_compatible() -> None:
+    """Keep release artifacts compatible with the Twine validation gate."""
+    pyproject = tomllib.loads(
+        (PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert pyproject["build-system"]["requires"] == ["hatchling==1.31.0"]
 
 
 def test_python_signoff_does_not_regress() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.12.*"
 
 [[package]]
 name = "altium-cruncher"
-version = "2026.8.10"
+version = "2026.8.11"
 source = { editable = "." }
 dependencies = [
     { name = "altium-monkey" },
@@ -40,7 +40,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "altium-monkey", specifier = "==2026.8.10" },
+    { name = "altium-monkey", specifier = "==2026.8.11" },
     { name = "build", marker = "extra == 'test'", specifier = ">=1.2.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "easyeda-monkey", specifier = ">=2026.5.26" },
@@ -70,7 +70,7 @@ dev = [
 
 [[package]]
 name = "altium-monkey"
-version = "2026.8.10"
+version = "2026.8.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "freetype-py" },
@@ -80,9 +80,9 @@ dependencies = [
     { name = "uharfbuzz" },
     { name = "wn-geometer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/ca/bade61c5726f2f3ecd8dcebde7f2f029256940e3377e29578c04b00983af/altium_monkey-2026.8.10.tar.gz", hash = "sha256:fefd4754bb6c373515c3a25860049fd003b36a6c0c6a816674aa588e2c8cb085", size = 4251824, upload-time = "2026-08-10T17:11:10.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/2b/e91208b044199154e73f1719bfb4ed2b830c992f281fdeea241f4e82afbd/altium_monkey-2026.8.11.tar.gz", hash = "sha256:271c183177d7da05fc4c0609e1b497ac52a34db8f39cacce4c940475c5cc857e", size = 4252274, upload-time = "2026-08-11T12:34:29.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/ba/be0f8be0d42984fd7105ddf53515f71a60879e2dd2d365f68c8bb8f91f1f/altium_monkey-2026.8.10-py3-none-any.whl", hash = "sha256:8e254f0b616eaa64d694d0516f0ee9a7cd41af665b129ebdd43b28b08d42dc5b", size = 4344683, upload-time = "2026-08-10T17:11:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d0/c8cb665f6e49960531abb5d2991a070a8b9102d5812812dd2750d0dc38d9/altium_monkey-2026.8.11-py3-none-any.whl", hash = "sha256:043195e87578ebf077ae223d54512b5e242b65aef15369d4da9d33cc433b7740", size = 4345228, upload-time = "2026-08-11T12:34:27.163Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Linked issue: #39

## Summary
- bump altium-cruncher to 2026.8.11
- pin published altium-monkey==2026.8.11 for corrected schematic Unicode decoding and serialization
- document propagation through design, DR, MegaMaid, and SVG workflows without changing graph/output contracts
- pin the build backend to Twine-compatible Hatchling 1.31.0 and govern it in L99

## Verification
- public Rack: 74 passed, 1 optional native skip; 12/12 subtests
- wheel and sdist built successfully
- Twine checks passed
- isolated installed-console test passed
- lock resolves the PyPI 2026.8.11 Altium Monkey artifacts