### PR TITLE
release: publish altium-cruncher 2026.8.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 2026.8.11.1
+
+- Consume pinned `altium-monkey==2026.8.11.post1`, carrying Python 3.14 dependency compatibility and exact duplicate-unannotated-component identity into all Altium-backed workflows.
+- Keep Cruncher's own Python support range and public output schemas unchanged.
+
 ## 2026.8.11
 
 - Consume pinned `altium-monkey==2026.8.11`, carrying the schematic Unicode record-encoding correction through `design`, Design Review, MegaMaid, `sch-svg`, and other Altium-backed workflows.

--- a/docs/releases/2026-08-11.md
+++ b/docs/releases/2026-08-11.md
@@ -1,19 +1,26 @@
 # Release Notes - 2026-08-11
 
-These notes describe the 2026-08-11 public release for `altium-cruncher`
-package version `2026.8.11`.
+These notes describe the latest 2026-08-11 public release for
+`altium-cruncher`, package version `2026.8.11.1`.
 
 ## Release Status
 
-This patch release consumes `altium-monkey==2026.8.11`. It carries corrected
-schematic Unicode record decoding and serialization into every Cruncher
-workflow that reads or rewrites SchDoc, SchLib, or project design data.
+This supplemental release consumes `altium-monkey==2026.8.11.post1`. It adds
+normal CPython 3.14 compatibility in the upstream parser and preserves exact
+component/pin ownership for distinct unannotated components that share a
+displayed designator. Cruncher's own Python support range remains unchanged.
 
 Please report issues with the exact command, version output, expected behavior,
 actual behavior, and a public-safe reproduction fixture when possible.
 
 ## Highlights
 
+- Duplicate unannotated component identity from the compiled schematic graph
+  flows through `design`, Design Review/`dr`, MegaMaid, and `sch-svg` without
+  downstream designator-based reconstruction.
+- The upstream runtime dependency set is compatible with normal CPython 3.12
+  through 3.14 and no longer includes unused Cascadio or Trimesh development
+  dependencies.
 - Unicode schematic fields are written through authoritative `%UTF8%<Field>`
   sidecars with CP1252-safe ordinary fallback fields.
 - Sidecar synthesis preserves leading and trailing whitespace exactly.
@@ -38,5 +45,5 @@ actual behavior, and a public-safe reproduction fixture when possible.
   all 12 subtests green.
 - Distribution build, Twine metadata, and isolated installed-console checks
   are release gates.
-- The dependency lock resolves the published `altium-monkey==2026.8.11` wheel
-  from PyPI rather than a source overlay.
+- The dependency lock resolves the published
+  `altium-monkey==2026.8.11.post1` wheel from PyPI rather than a source overlay.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "altium-cruncher"
-version = "2026.8.11"
+version = "2026.8.11.1"
 description = "Cross-platform Altium CLI utilities built on public altium-monkey"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -9,7 +9,7 @@ authors = [
     { name = "Wavenumber LLC" },
 ]
 dependencies = [
-    "altium-monkey==2026.8.11",
+    "altium-monkey==2026.8.11.post1",
     "colorama>=0.4.6",
     "easyeda-monkey>=2026.5.26",
     "json-with-comments>=1.2.10",

--- a/src/py/altium_cruncher/_version.py
+++ b/src/py/altium_cruncher/_version.py
@@ -8,7 +8,7 @@ from datetime import date
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 
-__version__ = "2026.8.11"
+__version__ = "2026.8.11.1"
 
 _DISTRIBUTION_NAME = "altium-cruncher"
 _CONTROLLED_DEPENDENCIES = (

--- a/tests/L99_signoff/test_L99_001_release_signoff.py
+++ b/tests/L99_signoff/test_L99_001_release_signoff.py
@@ -23,16 +23,16 @@ def _project_root() -> Path:
 
 
 PACKAGE_ROOT = _project_root()
-EXPECTED_VERSION = "2026.8.11"
+EXPECTED_VERSION = "2026.8.11.1"
 EXPECTED_RELEASE_DATE = date(2026, 8, 11)
 EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-08-11.md"
 CONTROLLED_DEPENDENCY_REQUIREMENTS = {
-    "altium-monkey": "==2026.8.11",
+    "altium-monkey": "==2026.8.11.post1",
     "wn-geometer": "==2026.6.10",
 }
 MINIMUM_CONTROLLED_DEPENDENCIES: dict[str, str] = {}
 EXACT_CONTROLLED_DEPENDENCIES = {
-    "altium-monkey": "2026.8.11",
+    "altium-monkey": "2026.8.11.post1",
     "wn-geometer": "2026.6.10",
 }
 
@@ -51,7 +51,7 @@ def test_version_contract_matches_date_based_release() -> None:
         2026,
         8,
         11,
-        None,
+        1,
     )
     assert version.release_date == EXPECTED_RELEASE_DATE
     assert version.release_date <= date.today()

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.12.*"
 
 [[package]]
 name = "altium-cruncher"
-version = "2026.8.11"
+version = "2026.8.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "altium-monkey" },
@@ -40,7 +40,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "altium-monkey", specifier = "==2026.8.11" },
+    { name = "altium-monkey", specifier = "==2026.8.11.post1" },
     { name = "build", marker = "extra == 'test'", specifier = ">=1.2.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "easyeda-monkey", specifier = ">=2026.5.26" },
@@ -70,7 +70,7 @@ dev = [
 
 [[package]]
 name = "altium-monkey"
-version = "2026.8.11"
+version = "2026.8.11.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "freetype-py" },
@@ -80,9 +80,9 @@ dependencies = [
     { name = "uharfbuzz" },
     { name = "wn-geometer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/2b/e91208b044199154e73f1719bfb4ed2b830c992f281fdeea241f4e82afbd/altium_monkey-2026.8.11.tar.gz", hash = "sha256:271c183177d7da05fc4c0609e1b497ac52a34db8f39cacce4c940475c5cc857e", size = 4252274, upload-time = "2026-08-11T12:34:29.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/02/a52327f5d6c1b2a7d39bfbe227843e74f5f6453b84ff9884efa3104581b4/altium_monkey-2026.8.11.post1.tar.gz", hash = "sha256:40c47a5d22ff3729324ba3ed0ffe5692f04fc0f246c00a1aebe0f97104aa0c05", size = 4254114, upload-time = "2026-08-12T02:06:59Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/d0/c8cb665f6e49960531abb5d2991a070a8b9102d5812812dd2750d0dc38d9/altium_monkey-2026.8.11-py3-none-any.whl", hash = "sha256:043195e87578ebf077ae223d54512b5e242b65aef15369d4da9d33cc433b7740", size = 4345228, upload-time = "2026-08-11T12:34:27.163Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c3/ce1447b5350fff47c84205dd4e1ca78b5eed6048bba417835c5225d52eb6/altium_monkey-2026.8.11.post1-py3-none-any.whl", hash = "sha256:6fb7bf6da1165b8b2947bcf2778cf7149084c2ea57aa21ae3b384e2235a72ac1", size = 4346509, upload-time = "2026-08-12T02:06:56.48Z" },
 ]
 
 [[package]]
@@ -499,21 +499,19 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "11.2.1"
+version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/cb/bb5c01fcd2a69335b86c22142b2bccfc3464087efb7fd382eee5ffc7fdf7/pillow-11.2.1.tar.gz", hash = "sha256:a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6", size = 47026707, upload-time = "2025-04-12T17:50:03.289Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/40/052610b15a1b8961f52537cc8326ca6a881408bc2bdad0d852edeb6ed33b/pillow-11.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:78afba22027b4accef10dbd5eed84425930ba41b3ea0a86fa8d20baaf19d807f", size = 3190185, upload-time = "2025-04-12T17:48:00.417Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/7e/b86dbd35a5f938632093dc40d1682874c33dcfe832558fc80ca56bfcb774/pillow-11.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78092232a4ab376a35d68c4e6d5e00dfd73454bd12b230420025fbe178ee3b0b", size = 3030306, upload-time = "2025-04-12T17:48:02.391Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/5c/467a161f9ed53e5eab51a42923c33051bf8d1a2af4626ac04f5166e58e0c/pillow-11.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25a5f306095c6780c52e6bbb6109624b95c5b18e40aab1c3041da3e9e0cd3e2d", size = 4416121, upload-time = "2025-04-12T17:48:04.554Z" },
-    { url = "https://files.pythonhosted.org/packages/62/73/972b7742e38ae0e2ac76ab137ca6005dcf877480da0d9d61d93b613065b4/pillow-11.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c7b29dbd4281923a2bfe562acb734cee96bbb129e96e6972d315ed9f232bef4", size = 4501707, upload-time = "2025-04-12T17:48:06.831Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/3a/427e4cb0b9e177efbc1a84798ed20498c4f233abde003c06d2650a6d60cb/pillow-11.2.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3e645b020f3209a0181a418bffe7b4a93171eef6c4ef6cc20980b30bebf17b7d", size = 4522921, upload-time = "2025-04-12T17:48:09.229Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/7c/d8b1330458e4d2f3f45d9508796d7caf0c0d3764c00c823d10f6f1a3b76d/pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b2dbea1012ccb784a65349f57bbc93730b96e85b42e9bf7b01ef40443db720b4", size = 4612523, upload-time = "2025-04-12T17:48:11.631Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/2f/65738384e0b1acf451de5a573d8153fe84103772d139e1e0bdf1596be2ea/pillow-11.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:da3104c57bbd72948d75f6a9389e6727d2ab6333c3617f0a89d72d4940aa0443", size = 4587836, upload-time = "2025-04-12T17:48:13.592Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c5/e795c9f2ddf3debb2dedd0df889f2fe4b053308bb59a3cc02a0cd144d641/pillow-11.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:598174aef4589af795f66f9caab87ba4ff860ce08cd5bb447c6fc553ffee603c", size = 4669390, upload-time = "2025-04-12T17:48:15.938Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ae/ca0099a3995976a9fce2f423166f7bff9b12244afdc7520f6ed38911539a/pillow-11.2.1-cp312-cp312-win32.whl", hash = "sha256:1d535df14716e7f8776b9e7fee118576d65572b4aad3ed639be9e4fa88a1cad3", size = 2332309, upload-time = "2025-04-12T17:48:17.885Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/18/24bff2ad716257fc03da964c5e8f05d9790a779a8895d6566e493ccf0189/pillow-11.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:14e33b28bf17c7a38eede290f77db7c664e4eb01f7869e37fa98a5aa95978941", size = 2676768, upload-time = "2025-04-12T17:48:19.655Z" },
-    { url = "https://files.pythonhosted.org/packages/da/bb/e8d656c9543276517ee40184aaa39dcb41e683bca121022f9323ae11b39d/pillow-11.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:21e1470ac9e5739ff880c211fc3af01e3ae505859392bf65458c224d0bf283eb", size = 2415087, upload-time = "2025-04-12T17:48:21.991Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Linked issue: #41

## Summary
- pin altium-monkey 2026.8.11.post1
- carry duplicate unannotated component identity into Cruncher workflows
- refresh release metadata and lock

## Verification
- Rack: 74 passed, 1 optional native skip
- wheel and sdist: Twine passed
- isolated installed-console test passed
- wn-dev-std check passed