### PR TITLE
release: altium-cruncher 2026.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2026.9.4
+
+- Update the controlled `altium-monkey` and `wn-geometer` dependencies to `2026.9.4`.
+
 ## 2026.8.21
 
 - Consume pinned `altium-monkey==2026.8.21`, carrying Altium-proven schematic source paint order, compiled-graph/index corrections, full Python/C++ parity, and record-decoding fixes into all Altium-backed workflows.

--- a/docs/releases/2026-09-04.md
+++ b/docs/releases/2026-09-04.md
@@ -1,0 +1,4 @@
+# Release Notes - 2026-09-04
+
+This release only updates the controlled `altium-monkey` and `wn-geometer`
+dependencies to `2026.9.4`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "altium-cruncher"
-version = "2026.8.21"
+version = "2026.9.4"
 description = "Cross-platform Altium CLI utilities built on public altium-monkey"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -9,13 +9,13 @@ authors = [
     { name = "Wavenumber LLC" },
 ]
 dependencies = [
-    "altium-monkey==2026.8.21",
+    "altium-monkey==2026.9.4",
     "colorama>=0.4.6",
     "easyeda-monkey>=2026.5.26",
     "json-with-comments>=1.2.10",
     "openpyxl>=3.1.0",
     "rich>=13.7.0",
-    "wn-geometer==2026.8.21",
+    "wn-geometer==2026.9.4",
 ]
 
 [project.optional-dependencies]

--- a/src/py/altium_cruncher/_version.py
+++ b/src/py/altium_cruncher/_version.py
@@ -8,7 +8,7 @@ from datetime import date
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as distribution_version
 
-__version__ = "2026.8.21"
+__version__ = "2026.9.4"
 
 _DISTRIBUTION_NAME = "altium-cruncher"
 _CONTROLLED_DEPENDENCIES = (

--- a/tests/L99_signoff/test_L99_001_release_signoff.py
+++ b/tests/L99_signoff/test_L99_001_release_signoff.py
@@ -23,17 +23,17 @@ def _project_root() -> Path:
 
 
 PACKAGE_ROOT = _project_root()
-EXPECTED_VERSION = "2026.8.21"
-EXPECTED_RELEASE_DATE = date(2026, 8, 21)
-EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-08-21.md"
+EXPECTED_VERSION = "2026.9.4"
+EXPECTED_RELEASE_DATE = date(2026, 9, 4)
+EXPECTED_RELEASE_NOTE = PACKAGE_ROOT / "docs" / "releases" / "2026-09-04.md"
 CONTROLLED_DEPENDENCY_REQUIREMENTS = {
-    "altium-monkey": "==2026.8.21",
-    "wn-geometer": "==2026.8.21",
+    "altium-monkey": "==2026.9.4",
+    "wn-geometer": "==2026.9.4",
 }
 MINIMUM_CONTROLLED_DEPENDENCIES: dict[str, str] = {}
 EXACT_CONTROLLED_DEPENDENCIES = {
-    "altium-monkey": "2026.8.21",
-    "wn-geometer": "2026.8.21",
+    "altium-monkey": "2026.9.4",
+    "wn-geometer": "2026.9.4",
 }
 
 
@@ -49,8 +49,8 @@ def test_version_contract_matches_date_based_release() -> None:
     assert version.string == EXPECTED_VERSION
     assert (version.major, version.minor, version.patch, version.build) == (
         2026,
-        8,
-        21,
+        9,
+        4,
         None,
     )
     assert version.release_date == EXPECTED_RELEASE_DATE

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.12.*"
 
 [[package]]
 name = "altium-cruncher"
-version = "2026.8.21"
+version = "2026.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "altium-monkey" },
@@ -40,7 +40,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "altium-monkey", specifier = "==2026.8.21" },
+    { name = "altium-monkey", specifier = "==2026.9.4" },
     { name = "build", marker = "extra == 'test'", specifier = ">=1.2.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "easyeda-monkey", specifier = ">=2026.5.26" },
@@ -52,7 +52,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.8.0" },
     { name = "twine", marker = "extra == 'test'", specifier = ">=5.0.0" },
-    { name = "wn-geometer", specifier = "==2026.8.21" },
+    { name = "wn-geometer", specifier = "==2026.9.4" },
     { name = "wn-rack", marker = "extra == 'test'", specifier = ">=1.1.0" },
 ]
 provides-extras = ["easyeda", "test"]
@@ -70,7 +70,7 @@ dev = [
 
 [[package]]
 name = "altium-monkey"
-version = "2026.8.21"
+version = "2026.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "freetype-py" },
@@ -82,9 +82,9 @@ dependencies = [
     { name = "uharfbuzz" },
     { name = "wn-geometer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/8b/b09207334a6767552b66203d9e4cb037e22611d9094d1be8b833cf97b293/altium_monkey-2026.8.21.tar.gz", hash = "sha256:d3d53947181fc35a72d94da6fad5e731617cd10d9fd39ca9c5648b698e1f1b7d", size = 4369782, upload-time = "2026-08-22T00:56:14.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/97/de285a2996eb6b203109cf9fdb84f93c0a4125c5992252247bc9a2488b18/altium_monkey-2026.9.4.tar.gz", hash = "sha256:7ed3cae93a7f93886a2ff49d8e75386d6af85ef24351f6cda0a32e569717f076", size = 4369718, upload-time = "2026-09-04T18:12:17.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/65/66d1d435d2cec5209936045f36f7a30b44979a54fa6f6fc9b8abf6d759be/altium_monkey-2026.8.21-py3-none-any.whl", hash = "sha256:7d0bb41984a6adbee659b161173132ac6c7dfa99d14a9ef8d5ed06598f0ba382", size = 4478231, upload-time = "2026-08-22T00:56:13.157Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/c4/2aa0eeecf40d576eb9d804bccfa793ff062330c1289bc329b00d2012e8b7/altium_monkey-2026.9.4-py3-none-any.whl", hash = "sha256:fd5e1fd7f43e8f22c182d7540bf840f35c449d7549221cad6c29199a38c2e27c", size = 4478218, upload-time = "2026-09-04T18:12:15.33Z" },
 ]
 
 [[package]]
@@ -850,13 +850,13 @@ wheels = [
 
 [[package]]
 name = "wn-geometer"
-version = "2026.8.21"
+version = "2026.9.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/66/c065a10cbdb915d5b2e4873729b615fbf708b5b3cec53b8dd71c6f667cd5/wn_geometer-2026.8.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3ddbd8bbeb591b22814810a0c5cfa306ef511ebdb6cb85424a4fea45b6b70239", size = 11456381, upload-time = "2026-08-22T00:09:37.515Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/3d/8dd8c5ca252009038bafbab4bf9f309e3dc297f71e608b97ceee367632b1/wn_geometer-2026.8.21-py3-none-manylinux_2_35_aarch64.whl", hash = "sha256:24bc0a05ef506ed2a096acf1c09ea959743a0ed3d24274d68b20fd0dfb236c7e", size = 14523846, upload-time = "2026-08-22T00:09:39.649Z" },
-    { url = "https://files.pythonhosted.org/packages/56/d6/17c6c3e77fbb146657d43b5084e8285b8ad4f03615a2565c99b6c5b90d40/wn_geometer-2026.8.21-py3-none-manylinux_2_35_x86_64.whl", hash = "sha256:c57b3bf18aeee125a3f0746c63b4a69d097214543e7bd1ebe2549a12a1adf07b", size = 15248280, upload-time = "2026-08-22T00:09:41.925Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/6c/c08f2cb621cce33ae480bc36e830f4a8b241610a7ad921bca8581570802c/wn_geometer-2026.8.21-py3-none-win_amd64.whl", hash = "sha256:d49f894b6c34aee69b6109dd5a54d4ae490d0f6ccc7491b651e1c39bfd51edd4", size = 7936528, upload-time = "2026-08-22T00:09:43.888Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0b/5cff3fa91c780522d2cc0f547ed9a45af8c856ecf6d2c10919b72f43beb9/wn_geometer-2026.9.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fcddf09d59cc34510eacec6fc343ec88f90f0577af140d638d5dde9c84408d47", size = 12046780, upload-time = "2026-09-04T15:46:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f7/ea5d20515e9d71c4be9488ceb436113ea9fd5f02d1a4225289649fa39b52/wn_geometer-2026.9.4-py3-none-manylinux_2_35_aarch64.whl", hash = "sha256:79d1a787524e8033bff193f5c0eb685a5696c4d9004d0dce675be0e3f672bd4f", size = 15250788, upload-time = "2026-09-04T15:46:23.041Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/bd/b29326eac231c5b0389fb2bb85ee5c293a57ec11855da2a27edf61461355/wn_geometer-2026.9.4-py3-none-manylinux_2_35_x86_64.whl", hash = "sha256:3f48e58167406e4103f5af5b0e37112fdf51ece7872e861775a50e5474f73352", size = 16050738, upload-time = "2026-09-04T15:46:25.158Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/0b/16cc0007d50326ea1ec9e883a4c24eba405a9a3bebe874f9fe50b2946d1c/wn_geometer-2026.9.4-py3-none-win_amd64.whl", hash = "sha256:05872d650f768151d41fb649788f5f7920a21ce7a36955091ff1d67823ce11d8", size = 8387581, upload-time = "2026-09-04T15:46:27.344Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Dependency-only release updating altium-monkey and wn-geometer to 2026.9.4.

Linked issue: #45